### PR TITLE
Maybe fixed history merge

### DIFF
--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -95,14 +95,12 @@ namespace Universalis.Application.Uploads.Behaviors
                     var head = existingHistory.Sales.FirstOrDefault();
                     for (var i = 0; i < minimizedSales.Count; i++)
                     {
-                        if (minimizedSales.Count == 0) break;
-                        if (minimizedSales[0].Equals(head))
+                        if (minimizedSales[i].Equals(head))
                         {
                             break;
                         }
 
                         existingHistory.Sales.Insert(0, minimizedSales[i]);
-                        minimizedSales.RemoveAt(0);
                     }
 
                     // Trims out duplicates and any invalid data


### PR DESCRIPTION
No clue why an element was getting removed from minimizedSales every iteration, but I believe that to be the culprit.

'i' increases with every iteration of the loop, but the element at the 0th index is also getting removed every iteration.  so we're esentially double-iterating, skipping every other entry.