### PR TITLE
WIP: API Client Generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=build-env /source/swagger.json /clients/swagger.json
 
 # Create clients
 RUN swagger-codegen generate -l python -o /clients/python -i /clients/swagger.json
-
+RUN swagger-codegen generate -l javascript -o /clients/javascript -i /clients/swagger.json
 
 # Run stage
 FROM mcr.microsoft.com/dotnet/aspnet:6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN ln -s /bin/echo /bin/systemctl \
     && wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
     && echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
+# Install Swashbuckle CLI Tool to generate swagger file 
+RUN dotnet tool install --global Swashbuckle.AspNetCore.Cli --version 6.3.0
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
 RUN apt-get update \
     && apt-get install -qqy --no-install-recommends mongodb-org=5.0.1
 
@@ -20,6 +24,17 @@ RUN mkdir /data \
 
 RUN mongod --fork --logpath /var/log/mongod.log \
     && ./build.sh --target Test Compile --configuration Release
+
+# Create Swagger file
+RUN swagger tofile --basepath https://universalis.app/ --serializeasv2 --output /source/swagger.json /source/artifacts/Universalis.Application.dll v2
+
+FROM swaggerapi/swagger-codegen-cli:latest
+WORKDIR /clients
+COPY --from=build-env /source/swagger.json /clients/swagger.json
+
+# Create clients
+RUN swagger-codegen generate -l python -o /clients/python -i /clients/swagger.json
+
 
 # Run stage
 FROM mcr.microsoft.com/dotnet/aspnet:6.0

--- a/src/Universalis.Application/Startup.cs
+++ b/src/Universalis.Application/Startup.cs
@@ -46,8 +46,11 @@ public class Startup
 
         services.AddAllOfType<IUploadBehavior>(new[] { typeof(Startup).Assembly }, ServiceLifetime.Singleton);
 
-        var cacheSize = int.Parse(Configuration["MarketCurrentDataCacheSize"]);
-        services.AddSingleton<ICache<CurrentlyShownQuery, CurrentlyShownView>>(new MemoryCache<CurrentlyShownQuery, CurrentlyShownView>(cacheSize));
+        
+        services.AddSingleton<ICache<CurrentlyShownQuery, CurrentlyShownView>>(_ => { 
+            var cacheSize = int.Parse(Configuration["MarketCurrentDataCacheSize"]);
+            return new MemoryCache<CurrentlyShownQuery, CurrentlyShownView>(cacheSize);
+        });
 
         services
             .AddAuthentication(NegotiateDefaults.AuthenticationScheme)

--- a/src/Universalis.DbAccess/DbAccessExtensions.cs
+++ b/src/Universalis.DbAccess/DbAccessExtensions.cs
@@ -10,7 +10,7 @@ public static class DbAccessExtensions
 {
     public static void AddDbAccessServices(this IServiceCollection sc, IConfiguration configuration)
     {
-        sc.AddSingleton<IMongoClient>(new MongoClient(configuration["MongoDbConnectionString"]));
+        sc.AddSingleton<IMongoClient>(_ => new MongoClient(configuration["MongoDbConnectionString"]));
 
         sc.AddSingleton<IMostRecentlyUpdatedDbAccess, MostRecentlyUpdatedDbAccess>();
         sc.AddSingleton<ICurrentlyShownDbAccess, CurrentlyShownDbAccess>();


### PR DESCRIPTION
I added an example with python and javascript, in the Dockerfile during the swagger-codegen stage the libraries get created in the format /clients/{lang} so /clients/javascript and /clients/python are added for now (I haven't tested the JS one). 

I ended up needing to make some dependencies be loaded by generator functions rather than in the initialization. For example 
`        sc.AddSingleton<IMongoClient>(new MongoClient(configuration["MongoDbConnectionString"]));
        sc.AddSingleton<IMongoClient>(_ => new MongoClient(configuration["MongoDbConnectionString"]));
`

Effectively this just means the object will be created when it is retrieved from the container the first time. This is because the Swashbuckle.Cli needs to be able to run Startup.ConfigureServices, and in the scenario where the docker container may not have the configuration available (because the entrypoint isn't necessarily getting called if the container is being run. 