### PR TITLE
Remove de/serialization methods from cache

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
@@ -25,7 +25,7 @@ public class CurrentlyShownControllerTests
         public IGameDataProvider GameData { get; private init; }
         public ICurrentlyShownDbAccess CurrentlyShown { get; private init; }
         public IHistoryDbAccess History { get; private init; }
-        public ICache<CurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
+        public ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
         public CurrentlyShownController Controller { get; private init; }
 
         public static TestResources Create()
@@ -33,7 +33,7 @@ public class CurrentlyShownControllerTests
             var gameData = new MockGameDataProvider();
             var currentlyShownDb = new MockCurrentlyShownDbAccess();
             var historyDb = new MockHistoryDbAccess();
-            var cache = new MemoryCache<CurrentlyShownQuery, CachedCurrentlyShownData>(1);
+            var cache = new MemoryCache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>(1);
             var controller = new CurrentlyShownController(gameData, currentlyShownDb, historyDb, cache);
             return new TestResources
             {

--- a/src/Universalis.Application.Tests/Controllers/V1/DeleteListingControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/DeleteListingControllerTests.cs
@@ -29,7 +29,7 @@ public class DeleteListingControllerTests
         public IFlaggedUploaderDbAccess FlaggedUploaders { get; private init; }
         public ICurrentlyShownDbAccess CurrentlyShown { get; private init; }
         public ITrustedSourceDbAccess TrustedSources { get; private init; }
-        public ICache<CurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
+        public ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
         public DeleteListingController Controller { get; private init; }
 
         public static TestResources Create()
@@ -38,7 +38,7 @@ public class DeleteListingControllerTests
             var flaggedUploaders = new MockFlaggedUploaderDbAccess();
             var currentlyShown = new MockCurrentlyShownDbAccess();
             var trustedSources = new MockTrustedSourceDbAccess();
-            var cache = new MemoryCache<CurrentlyShownQuery, CachedCurrentlyShownData>(1);
+            var cache = new MemoryCache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>(1);
             var controller = new DeleteListingController(gameData, trustedSources, currentlyShown, flaggedUploaders, cache);
             return new TestResources
             {

--- a/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
@@ -26,7 +26,7 @@ public class CurrentlyShownControllerTests
         public IGameDataProvider GameData { get; private init; }
         public ICurrentlyShownDbAccess CurrentlyShown { get; private init; }
         public IHistoryDbAccess History { get; private init; }
-        public ICache<CurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
+        public ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
         public CurrentlyShownController Controller { get; private init; }
 
         public static TestResources Create()
@@ -34,7 +34,7 @@ public class CurrentlyShownControllerTests
             var gameData = new MockGameDataProvider();
             var currentlyShownDb = new MockCurrentlyShownDbAccess();
             var historyDb = new MockHistoryDbAccess();
-            var cache = new MemoryCache<CurrentlyShownQuery, CachedCurrentlyShownData>(1);
+            var cache = new MemoryCache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>(1);
             var controller = new CurrentlyShownController(gameData, currentlyShownDb, historyDb, cache);
             return new TestResources
             {

--- a/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
@@ -25,7 +25,7 @@ public class MarketBoardUploadBehaviorTests
     {
         public ICurrentlyShownDbAccess CurrentlyShown { get; private init; }
         public IHistoryDbAccess History { get; private init; }
-        public ICache<CurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
+        public ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> Cache { get; private init; }
         public ISocketProcessor Sockets { get; private init; }
         public IGameDataProvider GameData { get; private init; }
         public IUploadBehavior Behavior { get; private init; }
@@ -34,7 +34,7 @@ public class MarketBoardUploadBehaviorTests
         {
             var currentlyShownDb = new MockCurrentlyShownDbAccess();
             var historyDb = new MockHistoryDbAccess();
-            var cache = new MemoryCache<CurrentlyShownQuery, CachedCurrentlyShownData>(1);
+            var cache = new MemoryCache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>(1);
             var sockets = new MockSocketProcessor();
             var gameData = new MockGameDataProvider();
             var behavior = new MarketBoardUploadBehavior(currentlyShownDb, historyDb, cache, sockets, gameData);

--- a/src/Universalis.Application/Caching/CachedCurrentlyShownData.cs
+++ b/src/Universalis.Application/Caching/CachedCurrentlyShownData.cs
@@ -19,8 +19,8 @@ public class CachedCurrentlyShownData : ICopyable
     public ICopyable Clone()
     {
         var copy = (CachedCurrentlyShownData)MemberwiseClone();
-        copy.Listings = Listings.ToList();
-        copy.RecentHistory = RecentHistory.ToList();
+        copy.Listings = Listings.Select(l => (ListingView)l.Clone()).ToList();
+        copy.RecentHistory = RecentHistory.Select(s => (SaleView)s.Clone()).ToList();
         return copy;
     }
 }

--- a/src/Universalis.Application/Caching/CachedCurrentlyShownData.cs
+++ b/src/Universalis.Application/Caching/CachedCurrentlyShownData.cs
@@ -1,17 +1,26 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Universalis.Application.Views.V1;
 
 namespace Universalis.Application.Caching;
 
-public class CachedCurrentlyShownData
+public class CachedCurrentlyShownData : ICopyable
 {
     public uint ItemId { get; set; }
-    
+
     public uint WorldId { get; set; }
 
     public long LastUploadTimeUnixMilliseconds { get; set; }
-    
+
     public List<ListingView> Listings { get; set; }
-    
+
     public List<SaleView> RecentHistory { get; set; }
+
+    public ICopyable Clone()
+    {
+        var copy = (CachedCurrentlyShownData)MemberwiseClone();
+        copy.Listings = Listings.ToList();
+        copy.RecentHistory = RecentHistory.ToList();
+        return copy;
+    }
 }

--- a/src/Universalis.Application/Caching/CachedCurrentlyShownQuery.cs
+++ b/src/Universalis.Application/Caching/CachedCurrentlyShownQuery.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace Universalis.Application.Caching;
+
+public class CachedCurrentlyShownQuery : IEquatable<CachedCurrentlyShownQuery>, ICopyable
+{
+    public uint WorldId { get; init; }
+
+    public uint ItemId { get; init; }
+
+    public bool Equals(CachedCurrentlyShownQuery other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return WorldId == other.WorldId && ItemId == other.ItemId;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        return obj.GetType() == GetType() && Equals((CachedCurrentlyShownQuery)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(WorldId, ItemId);
+    }
+
+    public ICopyable Clone()
+    {
+        return (CachedCurrentlyShownQuery)MemberwiseClone();
+    }
+
+    public static bool operator ==(CachedCurrentlyShownQuery left, CachedCurrentlyShownQuery right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(CachedCurrentlyShownQuery left, CachedCurrentlyShownQuery right)
+    {
+        return !Equals(left, right);
+    }
+}

--- a/src/Universalis.Application/Caching/CurrentlyShownCache.cs
+++ b/src/Universalis.Application/Caching/CurrentlyShownCache.cs
@@ -11,26 +11,35 @@ using Universalis.Entities.MarketBoard;
 
 namespace Universalis.Application.Caching;
 
-public class CurrentlyShownCache : MemoryCache<CurrentlyShownQuery, CachedCurrentlyShownData>
+public class CurrentlyShownCache : MemoryCache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>
 {
     private readonly ICurrentlyShownDbAccess _currentlyShownDb;
     private readonly IHistoryDbAccess _historyDb;
-    
+
     private static readonly Counter CacheHits = Metrics.CreateCounter("universalis_cache_hits", "Cache Hits");
     private static readonly Counter CacheMisses = Metrics.CreateCounter("universalis_cache_misses", "Cache Misses");
     private static readonly Gauge CacheEntries = Metrics.CreateGauge("universalis_cache_entries", "Cache Entries");
-    private static readonly Histogram CacheHitMs = Metrics.CreateHistogram("universalis_cache_hit_milliseconds", "Cache Hit Milliseconds");
-    private static readonly Histogram CacheMissMs = Metrics.CreateHistogram("universalis_cache_miss_milliseconds", "Cache Miss Milliseconds");
+
+    private static readonly Histogram CacheHitMs =
+        Metrics.CreateHistogram("universalis_cache_hit_milliseconds", "Cache Hit Milliseconds");
+
+    private static readonly Histogram CacheMissMs =
+        Metrics.CreateHistogram("universalis_cache_miss_milliseconds", "Cache Miss Milliseconds");
+
     private static readonly Counter CacheDeletes = Metrics.CreateCounter("universalis_cache_deletes", "Cache Deletes");
-    private static readonly Counter CacheEvictions = Metrics.CreateCounter("universalis_cache_evictions", "Cache Evictions");
-    
-    public CurrentlyShownCache(int size, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess historyDb) : base(size)
+
+    private static readonly Counter CacheEvictions =
+        Metrics.CreateCounter("universalis_cache_evictions", "Cache Evictions");
+
+    public CurrentlyShownCache(int size, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess historyDb) :
+        base(size)
     {
         _currentlyShownDb = currentlyShownDb;
         _historyDb = historyDb;
     }
 
-    public override async Task<CachedCurrentlyShownData> Get(CurrentlyShownQuery key, CancellationToken cancellationToken = default)
+    public override async Task<CachedCurrentlyShownData> Get(CachedCurrentlyShownQuery key,
+        CancellationToken cancellationToken = default)
     {
         // Fetch data from the cache
         var stopwatch = new Stopwatch();
@@ -47,8 +56,14 @@ public class CurrentlyShownCache : MemoryCache<CurrentlyShownQuery, CachedCurren
         }
 
         // Retrieve data from the database
-        var currentData = await _currentlyShownDb.Retrieve(key, cancellationToken);
-        var history = await _historyDb.Retrieve(new HistoryQuery { WorldId = key.WorldId, ItemId = key.ItemId, Count = 20 }, cancellationToken);
+        var currentData = await _currentlyShownDb.Retrieve(new CurrentlyShownQuery
+        {
+            WorldId = key.WorldId,
+            ItemId = key.ItemId,
+        }, cancellationToken);
+        var history =
+            await _historyDb.Retrieve(new HistoryQuery { WorldId = key.WorldId, ItemId = key.ItemId, Count = 20 },
+                cancellationToken);
 
         stopwatch.Stop();
         CacheMissMs.Observe(stopwatch.ElapsedMilliseconds);
@@ -88,13 +103,15 @@ public class CurrentlyShownCache : MemoryCache<CurrentlyShownQuery, CachedCurren
         return dataView;
     }
 
-    public override async Task Set(CurrentlyShownQuery key, CachedCurrentlyShownData value, CancellationToken cancellationToken = default)
+    public override async Task Set(CachedCurrentlyShownQuery key, CachedCurrentlyShownData value,
+        CancellationToken cancellationToken = default)
     {
         await base.Set(key, value, cancellationToken);
         CacheEntries.Set(Count);
     }
 
-    public override async Task<bool> Delete(CurrentlyShownQuery key, CancellationToken cancellationToken = default)
+    public override async Task<bool> Delete(CachedCurrentlyShownQuery key,
+        CancellationToken cancellationToken = default)
     {
         var result = await base.Delete(key, cancellationToken);
         if (result)

--- a/src/Universalis.Application/Caching/ICopyable.cs
+++ b/src/Universalis.Application/Caching/ICopyable.cs
@@ -1,0 +1,6 @@
+﻿namespace Universalis.Application.Caching;
+
+public interface ICopyable
+{
+    ICopyable Clone();
+}

--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -18,9 +18,9 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
 {
     protected readonly ICurrentlyShownDbAccess CurrentlyShown;
     protected readonly IHistoryDbAccess History;
-    protected readonly ICache<CurrentlyShownQuery, CachedCurrentlyShownData> Cache;
+    protected readonly ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> Cache;
 
-    public CurrentlyShownControllerBase(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess history, ICache<CurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData)
+    public CurrentlyShownControllerBase(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess history, ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData)
     {
         CurrentlyShown = currentlyShownDb;
         History = history;
@@ -142,7 +142,11 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
     private async Task<CachedCurrentlyShownData> FetchCachedCurrentlyShownData(uint worldId, uint itemId, CancellationToken cancellationToken = default)
     {
         var q = new CurrentlyShownQuery { WorldId = worldId, ItemId = itemId };
-        var d = await Cache.Get(q, cancellationToken);
+        var d = await Cache.Get(new CachedCurrentlyShownQuery
+        {
+            WorldId = q.WorldId,
+            ItemId = q.ItemId,
+        }, cancellationToken);
         if (d == null)
         {
             var cd = await CurrentlyShown.Retrieve(q, cancellationToken);

--- a/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
@@ -18,7 +18,7 @@ namespace Universalis.Application.Controllers.V1;
 [Route("api/{worldDcRegion}/{itemIds}")]
 public class CurrentlyShownController : CurrentlyShownControllerBase
 {
-    public CurrentlyShownController(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess historyDb, ICache<CurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData, currentlyShownDb, historyDb, cache) { }
+    public CurrentlyShownController(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess historyDb, ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData, currentlyShownDb, historyDb, cache) { }
 
     /// <summary>
     /// Retrieves the data currently shown on the market board for the requested item and world or data center.

--- a/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
+++ b/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
@@ -25,14 +25,14 @@ public class DeleteListingController : WorldDcRegionControllerBase
     private readonly ITrustedSourceDbAccess _trustedSourceDb;
     private readonly ICurrentlyShownDbAccess _currentlyShownDb;
     private readonly IFlaggedUploaderDbAccess _flaggedUploaderDb;
-    private readonly ICache<CurrentlyShownQuery, CachedCurrentlyShownData> _cache;
+    private readonly ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> _cache;
 
     public DeleteListingController(
         IGameDataProvider gameData,
         ITrustedSourceDbAccess trustedSourceDb,
         ICurrentlyShownDbAccess currentlyShownDb,
         IFlaggedUploaderDbAccess flaggedUploaderDb,
-        ICache<CurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData)
+        ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData)
     {
         _trustedSourceDb = trustedSourceDb;
         _currentlyShownDb = currentlyShownDb;
@@ -106,7 +106,11 @@ public class DeleteListingController : WorldDcRegionControllerBase
 
         await _currentlyShownDb.Update(itemData, query, cancellationToken);
 
-        await _cache.Delete(query, cancellationToken);
+        await _cache.Delete(new CachedCurrentlyShownQuery
+        {
+            WorldId = query.WorldId,
+            ItemId = query.ItemId,
+        }, cancellationToken);
 
         return Ok("Success");
     }

--- a/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
@@ -19,7 +19,7 @@ namespace Universalis.Application.Controllers.V2;
 [Route("api/v{version:apiVersion}/{worldDcRegion}/{itemIds}")]
 public class CurrentlyShownController : CurrentlyShownControllerBase
 {
-    public CurrentlyShownController(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess history, ICache<CurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData, currentlyShownDb, history, cache) { }
+    public CurrentlyShownController(IGameDataProvider gameData, ICurrentlyShownDbAccess currentlyShownDb, IHistoryDbAccess history, ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> cache) : base(gameData, currentlyShownDb, history, cache) { }
 
     /// <summary>
     /// Retrieves the data currently shown on the market board for the requested item and world or data center.

--- a/src/Universalis.Application/Startup.cs
+++ b/src/Universalis.Application/Startup.cs
@@ -47,7 +47,7 @@ public class Startup
         services.AddAllOfType<IUploadBehavior>(new[] { typeof(Startup).Assembly }, ServiceLifetime.Singleton);
 
         var cacheSize = int.Parse(Configuration["MarketCurrentDataCacheSize"]);
-        services.AddSingleton<ICache<CurrentlyShownQuery, CachedCurrentlyShownData>>(sc =>
+        services.AddSingleton<ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData>>(sc =>
         {
             var currentlyShownDb = sc.GetRequiredService<ICurrentlyShownDbAccess>();
             var historyDb = sc.GetRequiredService<IHistoryDbAccess>();

--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -25,7 +25,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
 {
     private readonly ICurrentlyShownDbAccess _currentlyShownDb;
     private readonly IHistoryDbAccess _historyDb;
-    private readonly ICache<CurrentlyShownQuery, CachedCurrentlyShownData> _cache;
+    private readonly ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> _cache;
     private readonly ISocketProcessor _sockets;
     private readonly IGameDataProvider _gdp;
 
@@ -34,7 +34,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
     public MarketBoardUploadBehavior(
         ICurrentlyShownDbAccess currentlyShownDb,
         IHistoryDbAccess historyDb,
-        ICache<CurrentlyShownQuery, CachedCurrentlyShownData> cache,
+        ICache<CachedCurrentlyShownQuery, CachedCurrentlyShownData> cache,
         ISocketProcessor sockets,
         IGameDataProvider gdp)
     {
@@ -190,7 +190,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
         var listings = newListings ?? existingCurrentlyShown?.Listings ?? new List<Listing>();
         var document = new CurrentlyShown(worldId, itemId, now, source.Name, listings);
 
-        if (await _cache.Delete(new CurrentlyShownQuery { ItemId = itemId, WorldId = worldId }, cancellationToken))
+        if (await _cache.Delete(new CachedCurrentlyShownQuery { ItemId = itemId, WorldId = worldId }, cancellationToken))
         {
             CacheDeletes.Inc();
         }

--- a/src/Universalis.Application/Views/V1/ListingView.cs
+++ b/src/Universalis.Application/Views/V1/ListingView.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
+using Universalis.Application.Caching;
 using Universalis.Application.Common;
 
 namespace Universalis.Application.Views.V1;
@@ -9,7 +10,7 @@ namespace Universalis.Application.Views.V1;
  * Please do not edit the field order unless it is unavoidable.
  */
 
-public class ListingView : IPriceable
+public class ListingView : IPriceable, ICopyable
 {
     /// <summary>
     /// The time that this listing was posted, in seconds since the UNIX epoch.
@@ -144,4 +145,9 @@ public class ListingView : IPriceable
     [BsonElement("total")]
     [JsonPropertyName("total")]
     public uint Total { get; set; }
+
+    public ICopyable Clone()
+    {
+        return (ListingView)MemberwiseClone();
+    }
 }

--- a/src/Universalis.Application/Views/V1/SaleView.cs
+++ b/src/Universalis.Application/Views/V1/SaleView.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
+using Universalis.Application.Caching;
 using Universalis.Application.Common;
 
 namespace Universalis.Application.Views.V1;
@@ -8,7 +9,7 @@ namespace Universalis.Application.Views.V1;
  * Please do not edit the field order unless it is unavoidable.
  */
 
-public class SaleView : IPriceable
+public class SaleView : IPriceable, ICopyable
 {
     /// <summary>
     /// Whether or not the item was high-quality.
@@ -75,4 +76,9 @@ public class SaleView : IPriceable
     [BsonElement("total")]
     [JsonPropertyName("total")]
     public uint Total { get; init; }
+
+    public ICopyable Clone()
+    {
+        return (SaleView)MemberwiseClone();
+    }
 }


### PR DESCRIPTION
This changes the cache to use MemberwiseClone to copy objects, rather than using JSON serialization to ensure a generalizable deep copy. This removes a significant amount of string object creation and unnecessary parsing, at the cost of requiring types to have their own clone implementations.