### PR TITLE
Add a field filter query parameter to the market board current data API

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Universalis.Application.Caching;
+using Universalis.Application.Controllers;
 using Universalis.Application.Controllers.V1;
 using Universalis.Application.Tests.Mocks.DbAccess.MarketBoard;
 using Universalis.Application.Tests.Mocks.GameData;
@@ -392,6 +394,52 @@ public class CurrentlyShownControllerTests
         Assert.Empty(history.Items);
         Assert.Equal("Crystal", history.DcName);
         Assert.Null(history.WorldId);
+    }
+    
+    [Fact]
+    public async Task Controller_Get_Succeeds_SingleItem_Fields()
+    {
+        var test = TestResources.Create();
+        var unixNowMs = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+        var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
+        await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
+        
+        var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
+        await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
+
+        var result = await test.Controller.Get("5333", "Crystal", fields: "listings.pricePerUnit,minPrice,recentHistory");
+        var currentlyShown = (CurrentlyShownView)Assert.IsType<OkObjectResult>(result).Value;
+
+        var json = JsonSerializer.Serialize(currentlyShown, new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
+
+        Assert.Matches(@"{""listings"":\[({""pricePerUnit"":\d+},?){100}],""recentHistory"":\[({""hq"":(false|true),""pricePerUnit"":\d+,""quantity"":\d+,""timestamp"":\d+,""worldName"":""Coeurl"",""worldID"":74,""buyerName"":null,""total"":\d+},?){5}],""minPrice"":\d+}", json);
+    }
+
+    [Fact]
+    public async Task Controller_Get_Succeeds_MultiItem_Fields()
+    {
+        var test = TestResources.Create();
+        var unixNowMs = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+        var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
+        await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
+        
+        var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
+        await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
+
+        var document2 = SeedDataGenerator.MakeCurrentlyShown(34, 5, unixNowMs);
+        await test.CurrentlyShown.Update(document2, new CurrentlyShownQuery { WorldId = 34, ItemId = 5 });
+        
+        var sales2 = SeedDataGenerator.MakeHistory(34, 5, unixNowMs).Sales;
+        await test.History.InsertSales(sales2, new HistoryQuery { WorldId = 34, ItemId = 5 });
+
+        var result = await test.Controller.Get("5,5333", "Crystal", fields: "items.listings.pricePerUnit,dcName,items.minPrice");
+        var currentlyShown = (CurrentlyShownMultiView)Assert.IsType<OkObjectResult>(result).Value;
+
+        var json = JsonSerializer.Serialize(currentlyShown, new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
+
+        Assert.Matches(@"{""items"":\[{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+},{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+}],""dcName"":""Crystal""}", json);
     }
 
     private static void AssertCurrentlyShownValidWorld(CurrentlyShown document, List<Sale> sales, CurrentlyShownView currentlyShown, IGameDataProvider gameData)

--- a/src/Universalis.Application/Common/InputProcessing.cs
+++ b/src/Universalis.Application/Common/InputProcessing.cs
@@ -25,4 +25,8 @@ public static class InputProcessing
             .Select(uint.Parse)
             .Distinct();
     }
+
+    public static HashSet<string> ParseFields(string fields) {
+        return new HashSet<string>(fields?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>());
+    }
 }

--- a/src/Universalis.Application/Common/PartiallySerializable.cs
+++ b/src/Universalis.Application/Common/PartiallySerializable.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Universalis.Application.Common; 
+
+public abstract class PartiallySerializable {
+    
+    [JsonIgnore] 
+    public HashSet<string> SerializableProperties { get; set; }
+}

--- a/src/Universalis.Application/Controllers/PartiallySerializableJsonConverter.cs
+++ b/src/Universalis.Application/Controllers/PartiallySerializableJsonConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Universalis.Application.Common;
+
+namespace Universalis.Application.Controllers;
+
+public class PartiallySerializableJsonConverterFactory : JsonConverterFactory {
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsAssignableTo(typeof(PartiallySerializable));
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) {
+        return (JsonConverter)Activator.CreateInstance(typeof(PartiallySerializableJsonConverter<>).MakeGenericType(typeToConvert),
+            BindingFlags.Instance | BindingFlags.Public, null, null, null);
+    }
+}
+
+public class PartiallySerializableJsonConverter<T> : JsonConverter<T> where T : PartiallySerializable {
+    public override bool HandleNull => false;
+
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as T;
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
+        writer.WriteStartObject();
+        foreach (var property in value.GetType().GetProperties()) {
+            var name = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
+            if (value.SerializableProperties != null && !value.SerializableProperties.Contains(name))
+                continue;
+            var propValue = property.GetValue(value);
+            var ignoreAttrib = property.GetCustomAttribute<JsonIgnoreAttribute>();
+            if (ignoreAttrib?.Condition == JsonIgnoreCondition.Always)
+                continue;
+            if (propValue == null && ignoreAttrib?.Condition == JsonIgnoreCondition.WhenWritingNull)
+                continue;
+            writer.WritePropertyName(name);
+            JsonSerializer.Serialize(writer, propValue, options);
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,7 +32,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// <param name="itemIds">The item ID or comma-separated item IDs to retrieve data for.</param>
     /// <param name="worldDcRegion">The world, data center, or region to retrieve data for. This may be an ID or a name. Regions should be specified as Japan, Europe, North-America, Oceania, China, or 中国.</param>
     /// <param name="listingsToReturn">The number of listings to return. By default, all listings will be returned.</param>
-    /// <param name="entriesToReturn">The number of entries to return. By default, a maximum of 5 entries will be returned.</param>
+    /// <param name="entriesToReturn">The number of recent history entries to return. By default, a maximum of 5 entries will be returned.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
     /// <param name="noGst">
@@ -40,6 +41,10 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// By default, GST is factored in. Set this parameter to true or 1 to prevent this.
     /// </param>
     /// <param name="hq">Filter for HQ listings and entries. By default, both HQ and NQ listings and entries will be returned.</param>
+    /// <param name="fields">
+    /// A comma separated list of fields that should be included in the response, if omitted will return all fields.
+    /// For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
+    /// </param>
     /// <param name="cancellationToken"></param>
     /// <response code="200">Data retrieved successfully.</response>
     /// <response code="400">The parameters were invalid.</response>
@@ -61,6 +66,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         [FromQuery] string hq = "",
         [FromQuery] string statsWithin = "",
         [FromQuery] string entriesWithin = "",
+        [FromQuery] string fields = "",
         CancellationToken cancellationToken = default)
     {
         if (itemIds == null || worldDcRegion == null)
@@ -110,6 +116,8 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         var noGstBool = Util.ParseUnusualBool(noGst);
         bool? hqBool = string.IsNullOrEmpty(hq) || hq.ToLowerInvariant() == "null" ? null : Util.ParseUnusualBool(hq);
 
+        var serializableProperties = BuildSerializableProperties(InputProcessing.ParseFields(fields));
+
         if (itemIdsArray.Length == 1)
         {
             var itemId = itemIdsArray[0];
@@ -120,15 +128,16 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
             }
 
             var (_, currentlyShownView) = await GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds, serializableProperties,
                 cancellationToken);
             return Ok(currentlyShownView);
         }
 
         // Multi-item handling
+        var itemsSerializableProperties = BuildSerializableProperties(serializableProperties, "items");
         var currentlyShownViewTasks = itemIdsArray
             .Select(itemId => GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds, itemsSerializableProperties,
                 cancellationToken))
             .ToList();
         var currentlyShownViews = await Task.WhenAll(currentlyShownViewTasks);
@@ -147,6 +156,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
             WorldName = worldDc.IsWorld ? worldDc.WorldName : null,
             DcName = worldDc.IsDc ? worldDc.DcName : null,
             UnresolvedItemIds = unresolvedItems,
+            SerializableProperties = serializableProperties,
         });
     }
 }

--- a/src/Universalis.Application/Startup.cs
+++ b/src/Universalis.Application/Startup.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Xml.XPath;
 using Universalis.Alerts;
 using Universalis.Application.Caching;
+using Universalis.Application.Controllers;
 using Universalis.Application.ExceptionFilters;
 using Universalis.Application.Realtime;
 using Universalis.Application.Swagger;
@@ -65,6 +66,8 @@ public class Startup
             options.Filters.Add<DecoderFallbackExceptionFilter>();
             options.Filters.Add<OperationCancelledExceptionFilter>();
             options.Filters.Add<PostgresExceptionFilter>();
+        }).AddJsonOptions(options => {
+            options.JsonSerializerOptions.Converters.Add(new PartiallySerializableJsonConverterFactory());
         });
 
         services.AddApiVersioning(options =>

--- a/src/Universalis.Application/Views/V1/CurrentlyShownMultiView.cs
+++ b/src/Universalis.Application/Views/V1/CurrentlyShownMultiView.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Universalis.Application.Common;
 
 namespace Universalis.Application.Views.V1;
 /*
@@ -7,7 +8,7 @@ namespace Universalis.Application.Views.V1;
  * Please do not edit the field order unless it is unavoidable.
  */
 
-public class CurrentlyShownMultiView
+public class CurrentlyShownMultiView : PartiallySerializable
 {
     /// <summary>
     /// The item IDs that were requested.

--- a/src/Universalis.Application/Views/V1/CurrentlyShownView.cs
+++ b/src/Universalis.Application/Views/V1/CurrentlyShownView.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Universalis.Application.Common;
 
 namespace Universalis.Application.Views.V1;
 
-public class CurrentlyShownView
+public class CurrentlyShownView : PartiallySerializable
 {
     /*
      * Note for anyone viewing this file: People rely on the field order (even though JSON is defined to be unordered).

--- a/src/Universalis.Application/Views/V1/ListingView.cs
+++ b/src/Universalis.Application/Views/V1/ListingView.cs
@@ -11,7 +11,7 @@ namespace Universalis.Application.Views.V1;
  * Please do not edit the field order unless it is unavoidable.
  */
 
-public class ListingView : IPriceable, ICopyable
+public class ListingView : PartiallySerializable, IPriceable, ICopyable
 {
     /// <summary>
     /// The time that this listing was posted, in seconds since the UNIX epoch.

--- a/src/Universalis.Application/Views/V1/SaleView.cs
+++ b/src/Universalis.Application/Views/V1/SaleView.cs
@@ -10,7 +10,7 @@ namespace Universalis.Application.Views.V1;
  * Please do not edit the field order unless it is unavoidable.
  */
 
-public class SaleView : IPriceable, ICopyable
+public class SaleView : PartiallySerializable, IPriceable, ICopyable
 {
     /// <summary>
     /// Whether or not the item was high-quality.

--- a/src/Universalis.Application/Views/V2/CurrentlyShownMultiViewV2.cs
+++ b/src/Universalis.Application/Views/V2/CurrentlyShownMultiViewV2.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Universalis.Application.Common;
 using Universalis.Application.Views.V1;
 
 namespace Universalis.Application.Views.V2;
 
-public class CurrentlyShownMultiViewV2
+public class CurrentlyShownMultiViewV2 : PartiallySerializable
 {
     /// <summary>
     /// The item IDs that were requested.


### PR DESCRIPTION
A lot of community projects, especially plugins, utilize the Universalis market board current data API to retrieve item prices.
With the addition of regional requests the amount of data transferred per item requested can reach significant volumes and especially for plugins, the developers cannot guarantee the internet connection of their users will be able to handle the downloads.

As the developer of Price Insight which tries to streamline the process of checking prices for the user as much as possible, using caching and prefetching, I'd like to keep the load to the Universalis server as minimal as possible too.

Requesting https://universalis.app/api/v2/North-America/37840,37843,38263,38268 currently requires ~2MB.

With this PR it will be possible to select the fields required, for example for PriceInsight:
https://universalis.app/api/v2/North-America/37840,37843,38263,38268?fields=items.listings.pricePerUnit,items.listings.hq,items.listings.worldID,items.recentHistory.pricePerUnit,items.recentHistory.hq,items.recentHistory.worldID which would reduce the size to ~350KB

This feature is inspired by AWS' and Kubernetes JSONPath support https://kubernetes.io/docs/reference/kubectl/jsonpath/
