### PR TITLE
Static-initialize reflected properties

### DIFF
--- a/src/Universalis.Application/Controllers/PartiallySerializableJsonConverter.cs
+++ b/src/Universalis.Application/Controllers/PartiallySerializableJsonConverter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -16,6 +18,21 @@ public class PartiallySerializableJsonConverterFactory : JsonConverterFactory {
 }
 
 public class PartiallySerializableJsonConverter<T> : JsonConverter<T> where T : PartiallySerializable {
+    // Store the type information of T statically once to avoid recomputing it thousands of times per second.
+    // This also relieves GC pressure significantly. Once this is upgraded to .NET 7, this should be refactored
+    // into a code generation-based converter to avoid this reflection altogether.
+    private static readonly PropertyInfo[] Properties = typeof(T).GetProperties();
+
+    // ReSharper disable once StaticMemberInGenericType
+    private static readonly IReadOnlyDictionary<string, string> JsonPropertyNames = Properties
+        .ToDictionary(prop => prop.Name,
+            prop => prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? prop.Name);
+    
+    // ReSharper disable once StaticMemberInGenericType
+    private static readonly IReadOnlyDictionary<string, JsonIgnoreAttribute> JsonIgnores = Properties
+        .ToDictionary(prop => prop.Name,
+            prop => prop.GetCustomAttribute<JsonIgnoreAttribute>());
+    
     public override bool HandleNull => false;
 
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
@@ -24,12 +41,12 @@ public class PartiallySerializableJsonConverter<T> : JsonConverter<T> where T : 
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
         writer.WriteStartObject();
-        foreach (var property in value.GetType().GetProperties()) {
-            var name = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
+        foreach (var property in Properties) {
+            var name = JsonPropertyNames[property.Name];
             if (value.SerializableProperties != null && !value.SerializableProperties.Contains(name))
                 continue;
             var propValue = property.GetValue(value);
-            var ignoreAttrib = property.GetCustomAttribute<JsonIgnoreAttribute>();
+            var ignoreAttrib = JsonIgnores[property.Name];
             if (ignoreAttrib?.Condition == JsonIgnoreCondition.Always)
                 continue;
             if (propValue == null && ignoreAttrib?.Condition == JsonIgnoreCondition.WhenWritingNull)


### PR DESCRIPTION
This change computes the properties and attributes of partially-serializable types once, during static initialization, rather than every read/write call. This should be replaced with code generation in .NET 7.