### PR TITLE
Add distributed cache for tax rates

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     image: ghcr.io/universalis-ffxiv/universalis-docs:latest
     ports:
       - "3998:3000"
+  memcached1:
+    image: memcached:1.6.17
+  memcached2:
+    image: memcached:1.6.17
   prometheus:
     image: prom/prometheus:v2.36.0
     network_mode: "host"

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -27,6 +27,14 @@ services:
       MYSQL_PASSWORD: dalamud
     volumes:
       - "./sqlinit:/docker-entrypoint-initdb.d"
+  memcached1:
+    image: memcached:1.6.17
+    ports:
+      - "4080:11212"
+  memcached2:
+    image: memcached:1.6.17
+    ports:
+      - "4081:11212"
   postgres:
     image: postgres:14.3
     command: postgres -c max_connections=100 -c shared_buffers=512MB

--- a/src/Universalis.Application/Universalis.Application.csproj
+++ b/src/Universalis.Application/Universalis.Application.csproj
@@ -37,7 +37,6 @@
     <ProjectReference Include="..\Universalis.DbAccess\Universalis.DbAccess.csproj" />
     <ProjectReference Include="..\Universalis.Entities\Universalis.Entities.csproj" />
     <ProjectReference Include="..\Universalis.GameData\Universalis.GameData.csproj" />
-    <ProjectReference Include="..\Universalis.Mogboard.WebUI\Universalis.Mogboard.WebUI.csproj" />
     <ProjectReference Include="..\Universalis.Mogboard\Universalis.Mogboard.csproj" />
   </ItemGroup>
 

--- a/src/Universalis.Application/appsettings.Development.json
+++ b/src/Universalis.Application/appsettings.Development.json
@@ -3,6 +3,7 @@
     "SqPack": "C:\\Program Files (x86)\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn\\game\\sqpack"
   },
   "MogboardPort": "4003",
+  "MemcachedConnectionString": "localhost:4080,localhost:4081",
   "RedisConnectionString": "localhost:4050,abortConnect=false",
   "PostgresConnectionString": "Host=localhost;Port=4052;Username=universalis;Password=universalis;Database=universalis;Maximum Pool Size=100;Max Auto Prepare=30"
 }

--- a/src/Universalis.Application/appsettings.Production.json
+++ b/src/Universalis.Application/appsettings.Production.json
@@ -3,6 +3,7 @@
     "SqPack": "/sqpack"
   },
   "MogboardPort": "7001",
+  "MemcachedConnectionString": "memcached1,memcached2",
   "RedisConnectionString": "65.108.107.235:6379,abortConnect=false",
   "PostgresConnectionString": "Host=localhost;Port=4051;Username=universalis;Password=universalis;Database=universalis;Maximum Pool Size=190;Max Auto Prepare=30"
 }

--- a/src/Universalis.DbAccess/MarketBoard/TaxRatesStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/TaxRatesStore.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Enyim.Caching.Memcached;
 using StackExchange.Redis;
 using Universalis.Entities.MarketBoard;
 
@@ -7,17 +9,35 @@ namespace Universalis.DbAccess.MarketBoard;
 
 public class TaxRatesStore : ITaxRatesStore
 {
+    /// <summary>
+    /// The primary store for tax rates data.
+    /// </summary>
     private readonly IConnectionMultiplexer _redis;
 
-    public TaxRatesStore(IConnectionMultiplexer redis)
+    /// <summary>
+    /// The near-cache for tax rates data. Microsoft DI doesn't allow for injecting
+    /// multiple objects of the same interface type, so we can have some fun with a
+    /// messier tech stack.
+    /// 
+    /// This should be replaced with a Redis cluster later, but making that work with
+    /// Microsoft DI will require a moderate refactor.
+    /// 
+    /// This Memcached client uses BinaryFormatter for complex objects, which ASP.NET
+    /// Core completely restricts (as it should). To work around this, JSON is used
+    /// for this instead.
+    /// </summary>
+    private readonly IMemcachedCluster _memcached;
+
+    public TaxRatesStore(IConnectionMultiplexer redis, IMemcachedCluster memcached)
     {
         _redis = redis;
+        _memcached = memcached;
     }
 
-    public Task SetTaxRates(uint worldId, TaxRates taxRates)
+    public async Task SetTaxRates(uint worldId, TaxRates taxRates)
     {
         var db = _redis.GetDatabase(RedisDatabases.Instance0.TaxRates);
-        return db.HashSetAsync(worldId.ToString(), new[]
+        var dbSet = db.HashSetAsync(worldId.ToString(), new[]
         {
             new HashEntry("Limsa Lominsa", taxRates.LimsaLominsa),
             new HashEntry("Gridania", taxRates.Gridania),
@@ -28,17 +48,34 @@ public class TaxRatesStore : ITaxRatesStore
             new HashEntry("Old Sharlayan", taxRates.OldSharlayan),
             new HashEntry("source", taxRates.UploadApplicationName),
         });
+
+        // Write through to the cache
+        var cache = _memcached.GetClient();
+        var cacheData = JsonSerializer.Serialize(taxRates.Clone());
+        var cacheSet = cache.SetAsync(GetCacheKey(worldId), cacheData);
+
+        await Task.WhenAll(dbSet, cacheSet);
     }
 
     public async Task<TaxRates> GetTaxRates(uint worldId)
     {
+        // Try to get the tax rates from the cache
+        var cache = _memcached.GetClient();
+        var cacheData1 = await cache.GetAsync<string>(GetCacheKey(worldId));
+        if (cacheData1 is not null)
+        {
+            var cachedObject = JsonSerializer.Deserialize<TaxRates>(cacheData1);
+            return cachedObject;
+        }
+
+        // Fetch the tax rates from the database
         var db = _redis.GetDatabase(RedisDatabases.Instance0.TaxRates);
         var key = worldId.ToString();
         var tasks = new[]
                 { "Limsa Lominsa", "Gridania", "Ul'dah", "Ishgard", "Kugane", "Crystarium", "Old Sharlayan", "source" }
             .Select(k => db.HashGetAsync(key, k));
         var values = await Task.WhenAll(tasks);
-        return new TaxRates
+        var taxRates = new TaxRates
         {
             LimsaLominsa = (int)values[0],
             Gridania = (int)values[1],
@@ -49,5 +86,15 @@ public class TaxRatesStore : ITaxRatesStore
             OldSharlayan = (int)values[6],
             UploadApplicationName = values[7],
         };
+
+        // Cache the data
+        var cacheData2 = JsonSerializer.Serialize(taxRates.Clone());
+        await cache.SetAsync(GetCacheKey(worldId), cacheData2);
+        return taxRates;
+    }
+
+    private static string GetCacheKey(uint worldId)
+    {
+        return $"tax-rates:${worldId}";
     }
 }

--- a/src/Universalis.DbAccess/Universalis.DbAccess.csproj
+++ b/src/Universalis.DbAccess/Universalis.DbAccess.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Enyim.Memcached2" Version="0.6.8" />
+    <PackageReference Include="Enyim.Memcached2.Extensions.AspNetCore" Version="0.6.8" />
     <PackageReference Include="FluentMigrator" Version="3.3.2" />
     <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.3.2" />


### PR DESCRIPTION
This uses Memcached to set up a distributed cache for tax rate data. Memcached is not ideal for this, but Making Redis work will require a moderate refactor, since I'm already using a Redis client for my primary store. Microsoft DI does not support providing multiple services on a single interface type.