### PR TITLE
Remove unnecessary and error-prone clones

### DIFF
--- a/src/Universalis.DbAccess/MarketBoard/MarketItemStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/MarketItemStore.cs
@@ -54,7 +54,7 @@ public class MarketItemStore : IMarketItemStore
 
         // Write through to the cache
         var cache = _memcached.GetClient();
-        var cacheData = JsonSerializer.Serialize(marketItem.Clone());
+        var cacheData = JsonSerializer.Serialize(marketItem);
         await cache.SetAsync(GetCacheKey(marketItem.WorldId, marketItem.ItemId), cacheData);
     }
 
@@ -89,7 +89,7 @@ public class MarketItemStore : IMarketItemStore
 
         // Write through to the cache
         var cache = _memcached.GetClient();
-        var cacheData = JsonSerializer.Serialize(marketItem.Clone());
+        var cacheData = JsonSerializer.Serialize(marketItem);
         await cache.SetAsync(GetCacheKey(marketItem.WorldId, marketItem.ItemId), cacheData);
     }
 

--- a/src/Universalis.DbAccess/MarketBoard/TaxRatesStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/TaxRatesStore.cs
@@ -56,7 +56,7 @@ public class TaxRatesStore : ITaxRatesStore
 
         // Write through to the cache
         var cache = _memcached.GetClient();
-        var cacheData = JsonSerializer.Serialize(taxRates.Clone());
+        var cacheData = JsonSerializer.Serialize(taxRates);
         var cacheSet = cache.SetAsync(GetCacheKey(worldId), cacheData);
 
         await Task.WhenAll(dbSet, cacheSet);
@@ -103,7 +103,7 @@ public class TaxRatesStore : ITaxRatesStore
         };
 
         // Cache the data
-        var cacheData2 = JsonSerializer.Serialize(taxRates.Clone());
+        var cacheData2 = JsonSerializer.Serialize(taxRates);
         await cache.SetAsync(GetCacheKey(worldId), cacheData2);
         return taxRates;
     }


### PR DESCRIPTION
These clones return an interface type instead of their own type, so they get serialized as empty objects. They're also unnecessary here.