### PR TITLE
Don't show stats for unmarketable items

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V1/Extra/Stats/RecentlyUpdatedItemsControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/Extra/Stats/RecentlyUpdatedItemsControllerTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Universalis.Application.Controllers.V1.Extra.Stats;
 using Universalis.Application.Tests.Mocks.DbAccess.Uploads;
+using Universalis.Application.Tests.Mocks.GameData;
 using Universalis.Application.Views.V1.Extra.Stats;
+using Universalis.GameData;
 using Xunit;
 
 namespace Universalis.Application.Tests.Controllers.V1.Extra.Stats;
@@ -12,7 +14,8 @@ public class RecentlyUpdatedItemsControllerTests
     public async Task Controller_Get_Succeeds()
     {
         var dbAccess = new MockRecentlyUpdatedItemsDbAccess();
-        var controller = new RecentlyUpdatedItemsController(dbAccess);
+        var gameData = new MockGameDataProvider();
+        var controller = new RecentlyUpdatedItemsController(dbAccess, gameData);
 
         await dbAccess.Push(5333);
 
@@ -27,7 +30,8 @@ public class RecentlyUpdatedItemsControllerTests
     public async Task Controller_Get_Succeeds_WhenNone()
     {
         var dbAccess = new MockRecentlyUpdatedItemsDbAccess();
-        var controller = new RecentlyUpdatedItemsController(dbAccess);
+        var gameData = new MockGameDataProvider();
+        var controller = new RecentlyUpdatedItemsController(dbAccess, gameData);
 
         var result = await controller.Get();
         Assert.IsAssignableFrom<RecentlyUpdatedItemsView>(result);

--- a/src/Universalis.Application/Controllers/V1/Extra/Stats/LeastRecentlyUpdatedItemsController.cs
+++ b/src/Universalis.Application/Controllers/V1/Extra/Stats/LeastRecentlyUpdatedItemsController.cs
@@ -69,13 +69,16 @@ public class LeastRecentlyUpdatedItemsController : WorldDcRegionControllerBase
         }
 
         var documents = await _mostRecentlyUpdatedDb.GetAllLeastRecent(
-            new MostRecentlyUpdatedManyQuery { WorldIds = worldIds, Count = count },
+            new MostRecentlyUpdatedManyQuery { WorldIds = worldIds, Count = Convert.ToInt32(count * 1.5) },
             cancellationToken);
 
+        var marketable = GameData.MarketableItemIds();
         var worlds = GameData.AvailableWorlds();
         return Ok(new LeastRecentlyUpdatedItemsView
         {
             Items = documents
+                .Where(o => marketable.Contains(o.ItemId))
+                .Take(count)
                 .Select(o => new WorldItemRecencyView
                 {
                     WorldId = o.WorldId,

--- a/src/Universalis.Application/Controllers/V1/Extra/Stats/MostRecentlyUpdatedItemsController.cs
+++ b/src/Universalis.Application/Controllers/V1/Extra/Stats/MostRecentlyUpdatedItemsController.cs
@@ -69,13 +69,16 @@ public class MostRecentlyUpdatedItemsController : WorldDcRegionControllerBase
         }
 
         var documents = await _mostRecentlyUpdatedDb.GetAllMostRecent(
-            new MostRecentlyUpdatedManyQuery { WorldIds = worldIds, Count = count },
+            new MostRecentlyUpdatedManyQuery { WorldIds = worldIds, Count = Convert.ToInt32(count * 1.5) },
             cancellationToken);
 
+        var marketable = GameData.MarketableItemIds();
         var worlds = GameData.AvailableWorlds();
         return Ok(new MostRecentlyUpdatedItemsView
         {
             Items = documents
+                .Where(o => marketable.Contains(o.ItemId))
+                .Take(count)
                 .Select(o => new WorldItemRecencyView
                 {
                     WorldId = o.WorldId,


### PR DESCRIPTION
This changes the recently-updated stats endpoints so that they do not show data for items that are not marketable.