### PR TITLE
Improve Redis and Hash performance

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V1/DeleteListingControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/DeleteListingControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Universalis.Application.Controllers.V1;
 using Universalis.Application.Realtime;
@@ -8,7 +7,6 @@ using Universalis.Application.Tests.Mocks.DbAccess.MarketBoard;
 using Universalis.Application.Tests.Mocks.DbAccess.Uploads;
 using Universalis.Application.Tests.Mocks.GameData;
 using Universalis.Application.Uploads.Schema;
-using Universalis.Common.Caching;
 using Universalis.DbAccess.AccessControl;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.DbAccess.Queries.MarketBoard;
@@ -63,7 +61,7 @@ public class DeleteListingControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -104,7 +102,7 @@ public class DeleteListingControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -145,7 +143,7 @@ public class DeleteListingControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -168,7 +166,7 @@ public class DeleteListingControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -193,14 +191,14 @@ public class DeleteListingControllerTests
         const string uploaderId = "ffff";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
         string uploaderIdHash;
         using (var sha256 = SHA256.Create())
         {
-            uploaderIdHash = Util.BytesToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(uploaderId)));
+            uploaderIdHash = Util.Hash(sha256, uploaderId);
         }
 
         await test.FlaggedUploaders.Create(new FlaggedUploader(uploaderIdHash));

--- a/src/Universalis.Application.Tests/Controllers/V1/Extra/Stats/SourceUploadCountsControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/Extra/Stats/SourceUploadCountsControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Universalis.Application.Controllers.V1.Extra.Stats;
 using Universalis.Application.Tests.Mocks.DbAccess.Uploads;
@@ -22,7 +21,7 @@ public class SourceUploadCountsControllerTests
         
         const string key = "blah";
         using var sha512 = SHA512.Create();
-        var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+        var hash = Util.Hash(sha512, key);
         var document = new ApiKey(hash, "something", true);
 
         await dbAccess.Create(document);

--- a/src/Universalis.Application.Tests/Controllers/V1/UploadControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/UploadControllerTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Universalis.Application.Controllers.V1;
 using Universalis.Application.Tests.Mocks.DbAccess;
@@ -48,7 +47,7 @@ public class UploadControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -77,7 +76,7 @@ public class UploadControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
@@ -95,7 +94,7 @@ public class UploadControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", false));
         }
 
@@ -114,14 +113,14 @@ public class UploadControllerTests
         const string uploaderId = "ffff";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 
         string uploaderIdHash;
         using (var sha256 = SHA256.Create())
         {
-            uploaderIdHash = Util.BytesToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(uploaderId)));
+            uploaderIdHash = Util.Hash(sha256, uploaderId);
         }
 
         await test.FlaggedUploaders.Create(new FlaggedUploader(uploaderIdHash));
@@ -148,7 +147,7 @@ public class UploadControllerTests
         const string key = "blah";
         using (var sha512 = SHA512.Create())
         {
-            var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+            var hash = Util.Hash(sha512, key);
             await test.TrustedSources.Create(new ApiKey(hash, "something", true));
         }
 

--- a/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
@@ -7,7 +7,6 @@ using Universalis.Application.Tests.Mocks.GameData;
 using Universalis.Application.Tests.Mocks.Realtime;
 using Universalis.Application.Uploads.Behaviors;
 using Universalis.Application.Uploads.Schema;
-using Universalis.Common.Caching;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.AccessControl;

--- a/src/Universalis.Application.Tests/Uploads/Behaviors/PlayerContentUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/PlayerContentUploadBehaviorTests.cs
@@ -38,7 +38,7 @@ public class PlayerContentUploadBehaviorTests
         Assert.Null(result);
         
         using var sha256 = SHA256.Create();
-        var contentIdHash = await Util.Hash(sha256, upload.ContentId);
+        var contentIdHash = Util.Hash(sha256, upload.ContentId);
 
         var data = await dbAccess.Retrieve(contentIdHash);
 

--- a/src/Universalis.Application.Tests/Uploads/Behaviors/SourceIncrementUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/SourceIncrementUploadBehaviorTests.cs
@@ -1,7 +1,5 @@
-﻿using System.IO;
-using System.Linq;
+﻿using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Universalis.Application.Tests.Mocks.DbAccess.Uploads;
 using Universalis.Application.Uploads.Behaviors;
@@ -25,8 +23,7 @@ public class SourceIncrementUploadBehaviorTests
             string keyHash;
             using (var sha256 = SHA256.Create())
             {
-                await using var keyStream = new MemoryStream(Encoding.UTF8.GetBytes(key));
-                keyHash = Util.BytesToString(await sha256.ComputeHashAsync(keyStream));
+                keyHash = Util.Hash(sha256, key);
             }
 
             var source = new ApiKey(keyHash, "something", true);

--- a/src/Universalis.Application.Tests/Uploads/Behaviors/TaxRatesUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/TaxRatesUploadBehaviorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Universalis.Application.Tests.Mocks.DbAccess.MarketBoard;
 using Universalis.Application.Uploads.Behaviors;
@@ -78,7 +77,7 @@ public class TaxRatesUploadBehaviorTests
 
         const string key = "blah";
         using var sha512 = SHA512.Create();
-        var hash = Util.BytesToString(sha512.ComputeHash(Encoding.UTF8.GetBytes(key)));
+        var hash = Util.Hash(sha512, key);
         var source = new ApiKey(hash, "something", true);
 
         var upload = new UploadParameters

--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -171,12 +171,12 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
             WorldId = cd.WorldId,
             ItemId = cd.ItemId,
             LastUploadTimeUnixMilliseconds = lastUploadTime,
-            Listings = (await Task.WhenAll((cd.Listings ?? new List<Listing>())
-                    .Select(l => Util.ListingToView(l, cancellationToken))))
+            Listings = (cd.Listings ?? Enumerable.Empty<Listing>())
+                .Select(Util.ListingToView)
                 .Where(s => s.PricePerUnit > 0)
                 .Where(s => s.Quantity > 0)
                 .ToList(),
-            RecentHistory = (h?.Sales ?? new List<Sale>())
+            RecentHistory = (h?.Sales ?? Enumerable.Empty<Sale>())
                 .Select(Util.SaleToView)
                 .Where(s => s.PricePerUnit > 0)
                 .Where(s => s.Quantity > 0)

--- a/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Universalis.Application.Common;
 using Universalis.Application.Swagger;
 using Universalis.Application.Views.V1;
-using Universalis.Common.Caching;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.GameData;
 

--- a/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
+++ b/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
@@ -116,7 +116,7 @@ public class DeleteListingController : WorldDcRegionControllerBase
         {
             WorldId = query.WorldId,
             ItemId = query.ItemId,
-            Listings = new List<ListingView> { await Util.ListingToView(listing, cts.Token) },
+            Listings = new List<ListingView> { Util.ListingToView(listing) },
         });
 
         return Ok("Success");

--- a/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
+++ b/src/Universalis.Application/Controllers/V1/DeleteListingController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
-using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Universalis.Application.Realtime;
@@ -67,8 +65,7 @@ public class DeleteListingController : WorldDcRegionControllerBase
         // Hash the uploader ID
         using (var sha256 = SHA256.Create())
         {
-            await using var uploaderIdStream = new MemoryStream(Encoding.UTF8.GetBytes(parameters.UploaderId));
-            parameters.UploaderId = Util.BytesToString(await sha256.ComputeHashAsync(uploaderIdStream, cancellationToken));
+            parameters.UploaderId = Util.Hash(sha256, parameters.UploaderId);
         }
 
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/Universalis.Application/Controllers/V1/UploadController.cs
+++ b/src/Universalis.Application/Controllers/V1/UploadController.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using System.Reflection;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -65,8 +63,7 @@ public class UploadController : ControllerBase
         // Hash the uploader ID
         using (var sha256 = SHA256.Create())
         {
-            await using var uploaderIdStream = new MemoryStream(Encoding.UTF8.GetBytes(parameters.UploaderId));
-            parameters.UploaderId = Util.BytesToString(await sha256.ComputeHashAsync(uploaderIdStream, cancellationToken));
+            parameters.UploaderId = Util.Hash(sha256, parameters.UploaderId);
         }
 
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/Universalis.Application/Startup.cs
+++ b/src/Universalis.Application/Startup.cs
@@ -22,9 +22,7 @@ using Universalis.Application.Realtime;
 using Universalis.Application.Realtime.Dispatchers;
 using Universalis.Application.Swagger;
 using Universalis.Application.Uploads.Behaviors;
-using Universalis.Common.Caching;
 using Universalis.DbAccess;
-using Universalis.DbAccess.MarketBoard;
 using Universalis.GameData;
 using Universalis.Mogboard;
 

--- a/src/Universalis.Application/TrustedSourceHashCache.cs
+++ b/src/Universalis.Application/TrustedSourceHashCache.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Concurrent;
-using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Universalis.DbAccess.AccessControl;
@@ -23,9 +21,7 @@ public static class TrustedSourceHashCache
         }
 
         using var sha512 = SHA512.Create();
-        await using var authStream = new MemoryStream(Encoding.UTF8.GetBytes(apiKey));
-        var hash = await sha512.ComputeHashAsync(authStream, cancellationToken);
-        hashString = Util.BytesToString(hash);
+        hashString = Util.Hash(sha512, apiKey);
 
         var source = await dbAccess.Retrieve(new TrustedSourceQuery { ApiKeySha512 = hashString }, cancellationToken);
         if (source == null)

--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -1,6 +1,5 @@
 ﻿using MassTransit;
 using Microsoft.AspNetCore.Mvc;
-using Prometheus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Universalis.Application.Realtime.Messages;
 using Universalis.Application.Uploads.Schema;
-using Universalis.Common.Caching;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.AccessControl;
@@ -158,10 +156,9 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                 {
                     WorldId = worldId,
                     ItemId = itemId,
-                    Listings = await addedListings
-                            .ToAsyncEnumerable()
-                            .SelectAwait(async l => await Util.ListingToView(l, cancellationToken))
-                            .ToListAsync(cancellationToken),
+                    Listings = addedListings
+                            .Select(Util.ListingToView)
+                            .ToList(),
                 }, cancellationToken);
             }
 
@@ -171,10 +168,9 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                 {
                     WorldId = worldId,
                     ItemId = itemId,
-                    Listings = await removedListings
-                            .ToAsyncEnumerable()
-                            .SelectAwait(async l => await Util.ListingToView(l, cancellationToken))
-                            .ToListAsync(cancellationToken),
+                    Listings = removedListings
+                            .Select(Util.ListingToView)
+                            .ToList(),
                 }, cancellationToken);
             }
         }

--- a/src/Universalis.Application/Uploads/Behaviors/PlayerContentUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/PlayerContentUploadBehavior.cs
@@ -26,7 +26,7 @@ public class PlayerContentUploadBehavior : IUploadBehavior
     public async Task<IActionResult> Execute(ApiKey source, UploadParameters parameters, CancellationToken cancellationToken = default)
     {
         using var sha256 = SHA256.Create();
-        var contentIdHash = await Util.Hash(sha256, parameters.ContentId, cancellationToken);
+        var contentIdHash = Util.Hash(sha256, parameters.ContentId);
         
         var existing = await _characterDb.Retrieve(contentIdHash, cancellationToken);
         var character = new Character(contentIdHash, parameters.CharacterName, existing?.WorldId);

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -74,32 +74,31 @@ public static class Util
 
         if (!string.IsNullOrEmpty(l.CreatorId))
         {
-            listingView.CreatorIdHash = await Hash(sha256, l.CreatorId, cancellationToken);
+            listingView.CreatorIdHash = Hash(sha256, l.CreatorId);
         }
 
         if (!string.IsNullOrEmpty(l.ListingId))
         {
-            listingView.ListingIdHash = await Hash(sha256, l.ListingId, cancellationToken);
+            listingView.ListingIdHash = Hash(sha256, l.ListingId);
         }
 
-        listingView.SellerIdHash = await Hash(sha256, l.SellerId, cancellationToken);
-        listingView.RetainerIdHash = await Hash(sha256, l.RetainerId, cancellationToken);
+        listingView.SellerIdHash = Hash(sha256, l.SellerId);
+        listingView.RetainerIdHash = Hash(sha256, l.RetainerId);
 
         return listingView;
     }
 
     /// <summary>
-    /// Hashes the provided string asynchronously.
+    /// Hashes the provided string.
     /// </summary>
     /// <param name="hasher">The hashing algorithm to use.</param>
     /// <param name="input">The input string.</param>
-    /// <param name="cancellationToken"></param>
     /// <returns>A hash representing the input string.</returns>
-    public static async Task<string> Hash(HashAlgorithm hasher, string input, CancellationToken cancellationToken = default)
+    public static string Hash(HashAlgorithm hasher, string input)
     {
-        var idBytes = Encoding.UTF8.GetBytes(input ?? "");
-        await using var dataStream = MemoryStreamPool.GetStream(idBytes);
-        return BytesToString(await hasher.ComputeHashAsync(dataStream, cancellationToken));
+        var bytes = Encoding.UTF8.GetBytes(input ?? "");
+        var hash = hasher.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
     }
 
     /// <summary>

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -43,9 +43,8 @@ public static class Util
     /// Converts a database listing into a listing view to be returned to external clients.
     /// </summary>
     /// <param name="l">The database listing.</param>
-    /// <param name="cancellationToken"></param>
     /// <returns>A listing view associated with the provided listing.</returns>
-    public static async Task<ListingView> ListingToView(Listing l, CancellationToken cancellationToken = default)
+    public static ListingView ListingToView(Listing l)
     {
         var ppu = l.PricePerUnit;
         var listingView = new ListingView

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -98,7 +98,7 @@ public static class Util
     {
         var bytes = Encoding.UTF8.GetBytes(input ?? "");
         var hash = hasher.ComputeHash(bytes);
-        return Convert.ToHexString(hash).ToLowerInvariant(); // https://github.com/dotnet/runtime/issues/60393
+        return BytesToString(hash);
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public static class Util
     /// <returns>A lowercase hexadecimal string representing the provided byte array.</returns>
     public static string BytesToString(byte[] bytes)
     {
-        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+        return Convert.ToHexString(bytes).ToLowerInvariant(); // https://github.com/dotnet/runtime/issues/60393
     }
 
     /// <summary>

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -98,7 +98,7 @@ public static class Util
     {
         var bytes = Encoding.UTF8.GetBytes(input ?? "");
         var hash = hasher.ComputeHash(bytes);
-        return Convert.ToHexString(hash);
+        return Convert.ToHexString(hash).ToLowerInvariant(); // https://github.com/dotnet/runtime/issues/60393
     }
 
     /// <summary>

--- a/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
-using System;
 using Universalis.DbAccess.MarketBoard;
-using Universalis.Entities.MarketBoard;
 using Xunit;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;

--- a/src/Universalis.DbAccess/AccessControl/TrustedSourceUploadCountStore.cs
+++ b/src/Universalis.DbAccess/AccessControl/TrustedSourceUploadCountStore.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using StackExchange.Redis;
 
 namespace Universalis.DbAccess.AccessControl;
 

--- a/src/Universalis.DbAccess/DbAccessExtensions.cs
+++ b/src/Universalis.DbAccess/DbAccessExtensions.cs
@@ -8,10 +8,6 @@ using System.Linq;
 using Universalis.DbAccess.AccessControl;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.DbAccess.Uploads;
-using Universalis.Entities;
-using Universalis.Entities.AccessControl;
-using Universalis.Entities.MarketBoard;
-using Universalis.Entities.Uploads;
 
 namespace Universalis.DbAccess;
 

--- a/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
@@ -219,19 +219,19 @@ public class CurrentlyShownStore : ICurrentlyShownStore
 
                 return new Listing
                 {
-                    ListingId = GetValueString(listingEntries[0]),
-                    Hq = GetValueBool(listingEntries[1]),
-                    OnMannequin = GetValueBool(listingEntries[2]),
-                    PricePerUnit = GetValueInt32(listingEntries[3]),
-                    Quantity = GetValueInt32(listingEntries[4]),
-                    DyeId = GetValueInt32(listingEntries[5]),
-                    CreatorId = GetValueString(listingEntries[6]),
-                    CreatorName = GetValueString(listingEntries[7]),
-                    LastReviewTimeUnixSeconds = GetValueInt64(listingEntries[8]),
-                    RetainerId = GetValueString(listingEntries[9]),
-                    RetainerName = GetValueString(listingEntries[10]),
-                    RetainerCityId = GetValueInt32(listingEntries[11]),
-                    SellerId = GetValueString(listingEntries[12]),
+                    ListingId = (string)listingEntries[0] ?? "",
+                    Hq = (bool)listingEntries[1],
+                    OnMannequin = (bool)listingEntries[2],
+                    PricePerUnit = (int)listingEntries[3],
+                    Quantity = (int)listingEntries[4],
+                    DyeId = (int)listingEntries[5],
+                    CreatorId = (string)listingEntries[6] ?? "",
+                    CreatorName = (string)listingEntries[7] ?? "",
+                    LastReviewTimeUnixSeconds = (long)listingEntries[8],
+                    RetainerId = (string)listingEntries[9] ?? "",
+                    RetainerName = (string)listingEntries[10] ?? "",
+                    RetainerCityId = (int)listingEntries[11],
+                    SellerId = (string)listingEntries[12] ?? "",
                     Materia = GetValueMateriaArray(listingEntries[13]),
                 };
             })
@@ -276,26 +276,6 @@ public class CurrentlyShownStore : ICurrentlyShownStore
 
         // Update the listings index
         _ = trans.StringSetAsync(listingsKey, SerializeObjectIds(newListingIds), expiry);
-    }
-
-    private static int GetValueInt32(RedisValue value)
-    {
-        return (int)value;
-    }
-
-    private static long GetValueInt64(RedisValue value)
-    {
-        return (long)value;
-    }
-
-    private static bool GetValueBool(RedisValue value)
-    {
-        return (bool)value;
-    }
-
-    private static string GetValueString(RedisValue value)
-    {
-        return value.IsNull ? "" : value;
     }
 
     private static List<Materia> GetValueMateriaArray(RedisValue value)

--- a/src/Universalis.DbAccess/MarketBoard/SaleStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/SaleStore.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Universalis.Entities.MarketBoard;
-using Condition = StackExchange.Redis.Condition;
 
 namespace Universalis.DbAccess.MarketBoard;
 

--- a/src/Universalis.Entities/AccessControl/ApiKey.cs
+++ b/src/Universalis.Entities/AccessControl/ApiKey.cs
@@ -32,7 +32,7 @@ public class ApiKey
     {
         using var sha512 = SHA512.Create();
         var hashBytes = sha512.ComputeHash(Encoding.UTF8.GetBytes(token));
-        var hashStr = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+        var hashStr = Convert.ToHexString(hashBytes).ToLowerInvariant();
         return new ApiKey(hashStr, name, canUpload);
     }
 }


### PR DESCRIPTION
The type of hashing that is done for IDs is extremely small and using Task results causing unnecessary allocations. If you want to parallelize it, it would be better to do ValueTask; however, we are not waiting on IO as we are getting back the results fairly quickly.

For Redis, I've removed the ToDictionary/HGETALL and swapped it for HMGET and specify the fields we want. This returns back the values in the same order we requested them and allows us to avoid those allocations. Additionally, we can remove the utility functions since the nullability of primitive types is the default value.

I've kicked the tires on my local testing setup, but I would like a review from production-y data.