### PR TITLE
Fix weird error when IDs are invalid

### DIFF
--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -37,6 +37,19 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         HashSet<string> fields = null,
         CancellationToken cancellationToken = default)
     {
+        if (!GameData.MarketableItemIds().Contains(itemId))
+        {
+            return (false, new CurrentlyShownView
+            {
+                ItemId = itemId,
+                WorldId = worldDcRegion.IsWorld ? worldDcRegion.WorldId : null,
+                WorldName = worldDcRegion.IsWorld ? worldDcRegion.WorldName : null,
+                DcName = worldDcRegion.IsDc ? worldDcRegion.DcName : null,
+                RegionName = worldDcRegion.IsRegion ? worldDcRegion.RegionName : null,
+                SerializableProperties = BuildSerializableProperties(fields),
+            });
+        }
+
         var cached = await Task.WhenAll(worldIds.Select(worldId => FetchCurrentlyShownData(worldId, itemId, cancellationToken)));
         var data = cached
             .Where(o => o != null)


### PR DESCRIPTION
Usually, invalid IDs should result in no data being found, but for some reason using 0 causes production to throw an exception. This change returns early if an invalid item ID is provided.