### PR TITLE
Gradually add listings to Postgres

### DIFF
--- a/devenv/.gitignore
+++ b/devenv/.gitignore
@@ -1,2 +1,3 @@
 data/
 redis/
+postgres/

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -53,7 +53,7 @@ services:
   postgres:
     image: postgres:14.3
     ports:
-      - "4051:5432"
+      - "4052:5432"
     environment:
       POSTGRES_USER: universalis
       POSTGRES_PASSWORD: universalis

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -50,6 +50,16 @@ services:
       - "9042:9042"
     volumes:
       - scylla-data:/var/lib/scylla
+  postgres:
+    image: postgres:14.3
+    ports:
+      - "4051:5432"
+    environment:
+      POSTGRES_USER: universalis
+      POSTGRES_PASSWORD: universalis
+    shm_size: 256mb
+    volumes:
+      - "./postgres:/var/lib/postgresql/data"
   redis:
     image: redis:7.0.0
     command: redis-server --save 600 1 --loglevel warning

--- a/src/Universalis.Application.Tests/SchemaSeedDataGenerator.cs
+++ b/src/Universalis.Application.Tests/SchemaSeedDataGenerator.cs
@@ -28,7 +28,7 @@ public static class SchemaSeedDataGenerator
                 SellerId = l.SellerId,
                 CreatorId = l.CreatorId,
                 DyeId = l.DyeId,
-                LastReviewTimeUnixSeconds = Convert.ToInt64(l.LastReviewTimeUnixSeconds),
+                LastReviewTimeUnixSeconds = new DateTimeOffset(l.LastReviewTime).ToUnixTimeSeconds(),
                 Materia = l.Materia
                     .Select(m => new Materia
                     {

--- a/src/Universalis.Application/Controllers/V3/Market/OverviewController.cs
+++ b/src/Universalis.Application/Controllers/V3/Market/OverviewController.cs
@@ -91,7 +91,7 @@ public class OverviewController : ControllerBase
         {
             ListingIdHash = listing.ListingId,
             World = world.Id,
-            LastReviewTimeUnixMilliseconds = listing.LastReviewTimeUnixSeconds * 1000,
+            LastReviewTimeUnixMilliseconds = new DateTimeOffset(listing.LastReviewTime).ToUnixTimeMilliseconds(),
             PricePerUnit = total / Convert.ToDecimal(listing.Quantity),
             Quantity = listing.Quantity,
             Total = total,

--- a/src/Universalis.Application/Program.cs
+++ b/src/Universalis.Application/Program.cs
@@ -1,5 +1,7 @@
 using System.Threading;
+using FluentMigrator.Runner;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -13,6 +15,14 @@ public static class Program
         ThreadPool.SetMinThreads(100, 100);
 
         var host = CreateHostBuilder(args).Build();
+
+        // Run database migrations
+        using (var scope = host.Services.CreateScope())
+        {
+            var runner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
+            runner.MigrateUp();
+        }
+
         host.Run();
     }
 
@@ -33,6 +43,6 @@ public static class Program
 #else
                         "wwwroot/_content/Universalis.Mogboard.WebUI"
 #endif
-                        );
+                    );
             });
 }

--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -217,7 +217,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                     DyeId = l.DyeId ?? 0,
                     CreatorId = Util.ParseUnusualId(l.CreatorId) ?? "",
                     CreatorName = l.CreatorName,
-                    LastReviewTimeUnixSeconds = l.LastReviewTimeUnixSeconds ?? 0,
+                    LastReviewTime = DateTimeOffset.FromUnixTimeSeconds(l.LastReviewTimeUnixSeconds ?? 0).UtcDateTime,
                     RetainerId = Util.ParseUnusualId(l.RetainerId) ?? "",
                     RetainerName = l.RetainerName,
                     RetainerCityId = l.RetainerCityId ?? 0,

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -64,7 +64,7 @@ public static class Util
             DyeId = l.DyeId,
             CreatorName = l.CreatorName ?? "",
             IsCrafted = !string.IsNullOrEmpty(l.CreatorId),
-            LastReviewTimeUnixSeconds = l.LastReviewTimeUnixSeconds,
+            LastReviewTimeUnixSeconds = new DateTimeOffset(l.LastReviewTime).ToUnixTimeSeconds(),
             RetainerName = l.RetainerName,
             RetainerCityId = l.RetainerCityId,
         };

--- a/src/Universalis.Application/appsettings.Development.json
+++ b/src/Universalis.Application/appsettings.Development.json
@@ -7,5 +7,5 @@
   "RabbitMqHostname": "localhost",
   "RedisCacheConnectionString": "localhost:4080,localhost:4081",
   "RedisConnectionString": "localhost:4050",
-  "PostgresConnectionString": "Host=localhost;Port=4052;Username=universalis;Password=universalis;Database=universalis;Maximum Pool Size=100;Max Auto Prepare=30"
+  "PostgresConnectionString": "Host=localhost;Port=4052;Username=universalis;Password=universalis;Database=universalis"
 }

--- a/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
@@ -54,7 +54,7 @@ public class CurrentlyShownStoreTests : IClassFixture<DbFixture>
             Assert.Equal(expected.DyeId, actual.DyeId);
             Assert.Equal(expected.CreatorId, actual.CreatorId);
             Assert.Equal(expected.CreatorName, actual.CreatorName);
-            Assert.Equal(expected.LastReviewTimeUnixSeconds, actual.LastReviewTimeUnixSeconds);
+            Assert.Equal(expected.LastReviewTime, actual.LastReviewTime);
             Assert.Equal(expected.SellerId, actual.SellerId);
         });
     }

--- a/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Universalis.DbAccess.MarketBoard;
 using Xunit;
@@ -55,6 +56,7 @@ public class CurrentlyShownStoreTests : IClassFixture<DbFixture>
             Assert.Equal(expected.CreatorId, actual.CreatorId);
             Assert.Equal(expected.CreatorName, actual.CreatorName);
             Assert.Equal(expected.LastReviewTime, actual.LastReviewTime);
+            Assert.Equal(DateTimeKind.Utc, actual.LastReviewTime.Kind);
             Assert.Equal(expected.SellerId, actual.SellerId);
         });
     }

--- a/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Universalis.DbAccess.MarketBoard;
+using Universalis.DbAccess.Queries.MarketBoard;
+using Xunit;
+
+namespace Universalis.DbAccess.Tests.MarketBoard;
+
+public class ListingStoreTests : IClassFixture<DbFixture>
+{
+    private readonly DbFixture _fixture;
+
+    public ListingStoreTests(DbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task UpsertLive_Works()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 2);
+        await store.UpsertLive(currentlyShown.Listings);
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task UpsertLiveRetrieveLive_Works()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 3);
+        await store.UpsertLive(currentlyShown.Listings);
+        var results = await store.RetrieveLive(new ListingQuery { ItemId = 3, WorldId = 93 });
+
+        Assert.NotNull(results);
+        Assert.All(currentlyShown.Listings.Zip(results), pair =>
+        {
+            var (expected, actual) = pair;
+            Assert.Equal(expected.ListingId, actual.ListingId);
+            Assert.Equal(3, actual.ItemId);
+            Assert.Equal(93, actual.WorldId);
+            Assert.Equal(expected.Hq, actual.Hq);
+            Assert.Equal(expected.OnMannequin, actual.OnMannequin);
+            Assert.Equal(expected.PricePerUnit, actual.PricePerUnit);
+            Assert.Equal(expected.Quantity, actual.Quantity);
+            Assert.Equal(expected.RetainerName, actual.RetainerName);
+            Assert.Equal(expected.RetainerId, actual.RetainerId);
+            Assert.Equal(expected.RetainerCityId, actual.RetainerCityId);
+            Assert.Equal(expected.DyeId, actual.DyeId);
+            Assert.Equal(expected.CreatorId, actual.CreatorId);
+            Assert.Equal(expected.CreatorName, actual.CreatorName);
+            Assert.Equal(expected.LastReviewTime, actual.LastReviewTime);
+            Assert.Equal(DateTimeKind.Utc, actual.LastReviewTime.Kind);
+            Assert.Equal(expected.SellerId, actual.SellerId);
+            Assert.True(actual.Live);
+        });
+    }
+    
+#if DEBUG
+    [Fact]
+#endif
+    public async Task UpsertLiveMultipleRetrieveLive_Works()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        for (var i = 0; i < 10; i++)
+        {
+            var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 5);
+            await store.UpsertLive(currentlyShown.Listings);
+            var results = await store.RetrieveLive(new ListingQuery { ItemId = 5, WorldId = 93 });
+
+            Assert.NotNull(results);
+            Assert.All(currentlyShown.Listings.Zip(results), pair =>
+            {
+                var (expected, actual) = pair;
+                Assert.Equal(expected.ListingId, actual.ListingId);
+                Assert.Equal(5, actual.ItemId);
+                Assert.Equal(93, actual.WorldId);
+                Assert.Equal(expected.Hq, actual.Hq);
+                Assert.Equal(expected.OnMannequin, actual.OnMannequin);
+                Assert.Equal(expected.PricePerUnit, actual.PricePerUnit);
+                Assert.Equal(expected.Quantity, actual.Quantity);
+                Assert.Equal(expected.RetainerName, actual.RetainerName);
+                Assert.Equal(expected.RetainerId, actual.RetainerId);
+                Assert.Equal(expected.RetainerCityId, actual.RetainerCityId);
+                Assert.Equal(expected.DyeId, actual.DyeId);
+                Assert.Equal(expected.CreatorId, actual.CreatorId);
+                Assert.Equal(expected.CreatorName, actual.CreatorName);
+                Assert.Equal(expected.LastReviewTime, actual.LastReviewTime);
+                Assert.Equal(DateTimeKind.Utc, actual.LastReviewTime.Kind);
+                Assert.Equal(expected.SellerId, actual.SellerId);
+                Assert.True(actual.Live);
+            });
+        }
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task RetrieveLive_ReturnsEmpty_WhenMissing()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        var results = await store.RetrieveLive(new ListingQuery { ItemId = 4, WorldId = 93 });
+        Assert.NotNull(results);
+        Assert.Empty(results);
+    }
+}

--- a/src/Universalis.DbAccess.Tests/MarketBoard/SaleStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/SaleStoreTests.cs
@@ -35,7 +35,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             BuyerName = "Hello World",
             OnMannequin = false,
             SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-            UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+            UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
         };
 
         await store.Insert(sale);
@@ -58,7 +58,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             BuyerName = "Hello World",
             OnMannequin = null,
             SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-            UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+            UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
         };
 
         await Assert.ThrowsAsync<ArgumentException>(() => store.Insert(sale));
@@ -90,7 +90,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             BuyerName = null,
             OnMannequin = false,
             SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-            UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+            UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
         };
 
         await Assert.ThrowsAsync<ArgumentException>(() => store.Insert(sale));
@@ -113,7 +113,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             BuyerName = "Hello World",
             OnMannequin = false,
             SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-            UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+            UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
         };
 
         await Assert.ThrowsAsync<ArgumentException>(() => store.Insert(sale));
@@ -136,7 +136,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             BuyerName = "Hello World",
             OnMannequin = false,
             SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-            UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+            UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
         };
 
         await store.Insert(sale);
@@ -155,6 +155,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             Assert.Equal(sale.BuyerName, result.BuyerName);
             Assert.Equal(sale.OnMannequin, result.OnMannequin);
             Assert.Equal(sale.SaleTime, result.SaleTime);
+            Assert.Equal(DateTimeKind.Utc, result.SaleTime.Kind);
             Assert.Equal(sale.UploaderIdHash, result.UploaderIdHash);
         });
     }
@@ -167,7 +168,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
         var store = _fixture.Services.GetRequiredService<ISaleStore>();
         var sales = new List<Sale>
         {
-            new Sale
+            new()
             {
                 Id = Guid.NewGuid(),
                 WorldId = 25,
@@ -178,9 +179,9 @@ public class SaleStoreTests : IClassFixture<DbFixture>
                 BuyerName = "Hello World",
                 OnMannequin = false,
                 SaleTime = new DateTime(2022, 10, 2, 0, 0, 0, DateTimeKind.Utc),
-                UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+                UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
             },
-            new Sale
+            new()
             {
                 Id = Guid.NewGuid(),
                 WorldId = 25,
@@ -191,7 +192,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
                 BuyerName = "Hello World",
                 OnMannequin = false,
                 SaleTime = new DateTime(2022, 10, 1, 0, 0, 0, DateTimeKind.Utc),
-                UploaderIdHash = "efuwhafejgj3weg0wrkporeh"
+                UploaderIdHash = "efuwhafejgj3weg0wrkporeh",
             }
         };
 
@@ -212,6 +213,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             Assert.Equal(sale.BuyerName, result.BuyerName);
             Assert.Equal(sale.OnMannequin, result.OnMannequin);
             Assert.Equal(sale.SaleTime, result.SaleTime);
+            Assert.Equal(DateTimeKind.Utc, result.SaleTime.Kind);
             Assert.Equal(sale.UploaderIdHash, result.UploaderIdHash);
         });
     }
@@ -241,6 +243,7 @@ public class SaleStoreTests : IClassFixture<DbFixture>
             Assert.Equal(sale.BuyerName, result.BuyerName);
             Assert.Equal(sale.OnMannequin, result.OnMannequin);
             Assert.Equal(new DateTimeOffset(sale.SaleTime).ToUnixTimeSeconds(), new DateTimeOffset(result.SaleTime).ToUnixTimeSeconds());
+            Assert.Equal(DateTimeKind.Utc, result.SaleTime.Kind);
             Assert.Equal(sale.UploaderIdHash, result.UploaderIdHash);
         });
     }

--- a/src/Universalis.DbAccess.Tests/SeedDataGenerator.cs
+++ b/src/Universalis.DbAccess.Tests/SeedDataGenerator.cs
@@ -26,7 +26,7 @@ public static class SeedDataGenerator
                 DyeId = (byte)rand.Next(0, 255),
                 CreatorId = rand.NextInt64().ToString(),
                 CreatorName = "Bingus Bongus",
-                LastReviewTimeUnixSeconds = (int)(DateTimeOffset.UtcNow.ToUnixTimeSeconds() - rand.Next(0, 360000)),
+                LastReviewTime = DateTime.UtcNow - TimeSpan.FromSeconds(rand.Next(0, 360000)),
                 RetainerId = rand.NextInt64().ToString(),
                 RetainerName = "xpotato",
                 RetainerCityId = 0xA,

--- a/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Universalis.DbAccess.Queries.MarketBoard;
+using Universalis.Entities.MarketBoard;
+
+namespace Universalis.DbAccess.MarketBoard;
+
+public interface IListingStore
+{
+    Task UpsertLive(IEnumerable<Listing> listingGroup, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Listing>> RetrieveLive(ListingQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/Universalis.DbAccess/MarketBoard/ListingStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/ListingStore.cs
@@ -76,7 +76,7 @@ public class ListingStore : IListingStore
         CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(
-            "SELECT listing_id, hq, on_mannequin, materia, unit_price, quantity, dye_id, creator_id, creator_name, last_review_time, retainer_id, retainer_name, retainer_city_id, seller_id FROM listing WHERE item_id = $1 AND world_id = $2 AND live ORDER BY unit_price");
+            "SELECT listing_id, item_id, world_id, hq, on_mannequin, materia, unit_price, quantity, dye_id, creator_id, creator_name, last_review_time, retainer_id, retainer_name, retainer_city_id, seller_id FROM listing WHERE item_id = $1 AND world_id = $2 AND live ORDER BY unit_price");
         command.Parameters.Add(new NpgsqlParameter<int>
         {
             TypedValue = query.ItemId,
@@ -92,23 +92,23 @@ public class ListingStore : IListingStore
         {
             listings.Add(new Listing
             {
-                ItemId = query.ItemId,
-                WorldId = query.WorldId,
-                Live = true,
                 ListingId = reader.GetString(0),
-                Hq = reader.GetBoolean(1),
-                OnMannequin = reader.GetBoolean(2),
-                Materia = ConvertMateriaFromJArray(reader.GetFieldValue<JArray>(3)),
-                PricePerUnit = reader.GetInt32(4),
-                Quantity = reader.GetInt32(5),
-                DyeId = reader.GetInt32(6),
-                CreatorId = reader.GetString(7),
-                CreatorName = reader.GetString(8),
-                LastReviewTime = reader.GetDateTime(9),
-                RetainerId = reader.GetString(10),
-                RetainerName = reader.GetString(11),
-                RetainerCityId = reader.GetInt32(12),
-                SellerId = reader.GetString(13),
+                ItemId = reader.GetInt32(1),
+                WorldId = reader.GetInt32(2),
+                Hq = reader.GetBoolean(3),
+                OnMannequin = reader.GetBoolean(4),
+                Materia = ConvertMateriaFromJArray(reader.GetFieldValue<JArray>(5)),
+                PricePerUnit = reader.GetInt32(6),
+                Quantity = reader.GetInt32(7),
+                DyeId = reader.GetInt32(8),
+                CreatorId = reader.GetString(9),
+                CreatorName = reader.GetString(10),
+                LastReviewTime = reader.GetDateTime(11),
+                RetainerId = reader.GetString(12),
+                RetainerName = reader.GetString(13),
+                RetainerCityId = reader.GetInt32(14),
+                SellerId = reader.GetString(15),
+                Live = true,
             });
         }
 

--- a/src/Universalis.DbAccess/MarketBoard/ListingStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/ListingStore.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Npgsql;
+using NpgsqlTypes;
+using Universalis.DbAccess.Queries.MarketBoard;
+using Universalis.Entities;
+using Universalis.Entities.MarketBoard;
+
+namespace Universalis.DbAccess.MarketBoard;
+
+public class ListingStore : IListingStore
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public ListingStore(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task UpsertLive(IEnumerable<Listing> listingGroup, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        var listingIds = new List<string>();
+        foreach (var listing in listingGroup)
+        {
+            await using var command = new NpgsqlCommand(
+                "INSERT INTO listing (listing_id, item_id, world_id, hq, on_mannequin, materia, unit_price, quantity, dye_id, creator_id, creator_name, last_review_time, retainer_id, retainer_name, retainer_city_id, seller_id, live) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING listing_id",
+                connection, transaction)
+            {
+                Parameters =
+                {
+                    new NpgsqlParameter<string> { TypedValue = listing.ListingId },
+                    new NpgsqlParameter<int> { TypedValue = listing.ItemId },
+                    new NpgsqlParameter<int> { TypedValue = listing.WorldId },
+                    new NpgsqlParameter<bool> { TypedValue = listing.Hq },
+                    new NpgsqlParameter<bool> { TypedValue = listing.OnMannequin },
+                    new NpgsqlParameter { Value = ConvertMateriaToJArray(listing.Materia), NpgsqlDbType = NpgsqlDbType.Jsonb },
+                    new NpgsqlParameter<int> { TypedValue = listing.PricePerUnit },
+                    new NpgsqlParameter<int> { TypedValue = listing.Quantity },
+                    new NpgsqlParameter<int> { TypedValue = listing.DyeId },
+                    new NpgsqlParameter<string> { TypedValue = listing.CreatorId },
+                    new NpgsqlParameter<string> { TypedValue = listing.CreatorName },
+                    new NpgsqlParameter<DateTime> { TypedValue = listing.LastReviewTime },
+                    new NpgsqlParameter<string> { TypedValue = listing.RetainerId },
+                    new NpgsqlParameter<string> { TypedValue = listing.RetainerName },
+                    new NpgsqlParameter<int> { TypedValue = listing.RetainerCityId },
+                    new NpgsqlParameter<string> { TypedValue = listing.SellerId },
+                    new NpgsqlParameter<bool> { TypedValue = true }, // listing.Live
+                },
+            };
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            await reader.ReadAsync(cancellationToken);
+            listingIds.Add(reader.GetString(0));
+        }
+
+        await using var killOld = new NpgsqlCommand("UPDATE listing SET live = FALSE WHERE listing_id != ANY($1)", connection, transaction)
+        {
+            Parameters =
+            {
+                new NpgsqlParameter<string[]> { TypedValue = listingIds.ToArray() },
+            },
+        };
+
+        await killOld.ExecuteNonQueryAsync(cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<Listing>> RetrieveLive(ListingQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(
+            "SELECT listing_id, hq, on_mannequin, materia, unit_price, quantity, dye_id, creator_id, creator_name, last_review_time, retainer_id, retainer_name, retainer_city_id, seller_id FROM listing WHERE item_id = $1 AND world_id = $2 AND live ORDER BY unit_price");
+        command.Parameters.Add(new NpgsqlParameter<int>
+        {
+            TypedValue = query.ItemId,
+        });
+        command.Parameters.Add(new NpgsqlParameter<int>
+        {
+            TypedValue = query.WorldId,
+        });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        var listings = new List<Listing>();
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            listings.Add(new Listing
+            {
+                ItemId = query.ItemId,
+                WorldId = query.WorldId,
+                Live = true,
+                ListingId = reader.GetString(0),
+                Hq = reader.GetBoolean(1),
+                OnMannequin = reader.GetBoolean(2),
+                Materia = ConvertMateriaFromJArray(reader.GetFieldValue<JArray>(3)),
+                PricePerUnit = reader.GetInt32(4),
+                Quantity = reader.GetInt32(5),
+                DyeId = reader.GetInt32(6),
+                CreatorId = reader.GetString(7),
+                CreatorName = reader.GetString(8),
+                LastReviewTime = reader.GetDateTime(9),
+                RetainerId = reader.GetString(10),
+                RetainerName = reader.GetString(11),
+                RetainerCityId = reader.GetInt32(12),
+                SellerId = reader.GetString(13),
+            });
+        }
+
+        return listings;
+    }
+    
+    private static JArray ConvertMateriaToJArray(IEnumerable<Materia> materia)
+    {
+        return materia
+            .Select(m => new JObject { ["slot_id"] = m.SlotId, ["materia_id"] = m.MateriaId })
+            .Aggregate(new JArray(), (array, o) =>
+            {
+                array.Add(o);
+                return array;
+            });
+    }
+    
+    private static List<Materia> ConvertMateriaFromJArray(IEnumerable<JToken> materia)
+    {
+        return materia
+            .Select(m => new Materia { SlotId = m["slot_id"].Value<int>(), MateriaId = m["materia_id"].Value<int>() })
+            .ToList();
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0001_CreateMarketItemTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0001_CreateMarketItemTable.cs
@@ -1,0 +1,22 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(1)]
+public class CreateMarketItemTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("market_item")
+            .WithColumn("item_id").AsInt32().NotNullable()
+            .WithColumn("world_id").AsInt32().NotNullable()
+            .WithColumn("updated").AsDateTimeOffset().NotNullable();
+        
+        Create.PrimaryKey().OnTable("market_item").Columns("item_id", "world_id");
+    }
+
+    public override void Down()
+    {
+        Delete.Table("market_item");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0002_CreateSaleTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0002_CreateSaleTable.cs
@@ -1,0 +1,30 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(2)]
+public class CreateSaleTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("sale")
+            .WithColumn("id").AsGuid().NotNullable().PrimaryKey()
+            .WithColumn("item_id").AsInt32().NotNullable()
+            .WithColumn("world_id").AsInt32().NotNullable()
+            .WithColumn("hq").AsBoolean().NotNullable()
+            .WithColumn("unit_price").AsInt64().NotNullable()
+            .WithColumn("quantity").AsInt32()
+            .WithColumn("buyer_name").AsString()
+            .WithColumn("sale_time").AsDateTimeOffset().NotNullable()
+            .WithColumn("uploader_id").AsString();
+
+        Create.ForeignKey()
+            .FromTable("sale").ForeignColumns("item_id", "world_id")
+            .ToTable("market_item").PrimaryColumns("item_id", "world_id");
+    }
+
+    public override void Down()
+    {
+        Delete.Table("sale");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0003_CreateApiKeyTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0003_CreateApiKeyTable.cs
@@ -1,0 +1,19 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(3)]
+public class CreateApiKeyTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("api_key")
+            .WithColumn("token_sha512").AsString().NotNullable().PrimaryKey()
+            .WithColumn("can_upload").AsBoolean().NotNullable();
+    }
+
+    public override void Down()
+    {
+        Delete.Table("api_key");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0004_AddApiKeyName.cs
+++ b/src/Universalis.DbAccess/Migrations/0004_AddApiKeyName.cs
@@ -1,0 +1,19 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(4)]
+public class AddApiKeyName : Migration
+{
+    public override void Up()
+    {
+        Alter.Table("api_key")
+            .AddColumn("name").AsString();
+    }
+
+    public override void Down()
+    {
+        Delete.Column("name")
+            .FromTable("api_key");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0005_MakeColumnsNullable.cs
+++ b/src/Universalis.DbAccess/Migrations/0005_MakeColumnsNullable.cs
@@ -1,0 +1,33 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(5)]
+public class MakeColumnsNullable : Migration
+{
+    public override void Up()
+    {
+        Alter.Column("quantity")
+            .OnTable("sale").AsInt32().Nullable();
+        Alter.Column("buyer_name")
+            .OnTable("sale").AsString().Nullable();
+        Alter.Column("uploader_id")
+            .OnTable("sale").AsString().Nullable();
+        
+        Alter.Column("name")
+            .OnTable("api_key").AsString().Nullable();
+    }
+
+    public override void Down()
+    {
+        Alter.Column("quantity")
+            .OnTable("sale").AsInt32().NotNullable();
+        Alter.Column("buyer_name")
+            .OnTable("sale").AsString().NotNullable();
+        Alter.Column("uploader_id")
+            .OnTable("sale").AsString().NotNullable();
+        
+        Alter.Column("name")
+            .OnTable("api_key").AsString().NotNullable();
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0006_CreateCharacterTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0006_CreateCharacterTable.cs
@@ -1,0 +1,20 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(6)]
+public class CreateCharacterTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("character")
+            .WithColumn("content_id_sha256").AsString().NotNullable().PrimaryKey()
+            .WithColumn("name").AsString().NotNullable()
+            .WithColumn("world_id").AsInt32().Nullable();
+    }
+
+    public override void Down()
+    {
+        Delete.Table("character");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0007_CreateFlaggedUploaderTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0007_CreateFlaggedUploaderTable.cs
@@ -1,0 +1,18 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(7)]
+public class CreateFlaggedUploaderTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("flagged_uploader")
+            .WithColumn("id_sha256").AsString().NotNullable().PrimaryKey();
+    }
+
+    public override void Down()
+    {
+        Delete.Table("flagged_uploader");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0008_AddMannequinToSales.cs
+++ b/src/Universalis.DbAccess/Migrations/0008_AddMannequinToSales.cs
@@ -1,0 +1,19 @@
+﻿using FluentMigrator;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(8)]
+public class AddMannequinToSales : Migration
+{
+    public override void Up()
+    {
+        Alter.Table("sale")
+            .AddColumn("mannequin").AsBoolean().Nullable();
+    }
+
+    public override void Down()
+    {
+        Delete.Column("mannequin")
+            .FromTable("sale");
+    }
+}

--- a/src/Universalis.DbAccess/Migrations/0009_CreateListingTable.cs
+++ b/src/Universalis.DbAccess/Migrations/0009_CreateListingTable.cs
@@ -1,0 +1,45 @@
+﻿using FluentMigrator;
+using FluentMigrator.Infrastructure;
+using FluentMigrator.Postgres;
+
+namespace Universalis.DbAccess.Migrations;
+
+[Migration(9)]
+public class CreateListingTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("listing")
+            .WithColumn("listing_id").AsString().NotNullable().PrimaryKey()
+            .WithColumn("item_id").AsInt32().NotNullable()
+            .WithColumn("world_id").AsInt32().NotNullable()
+            .WithColumn("live").AsBoolean().NotNullable()
+            .WithColumn("hq").AsBoolean().NotNullable()
+            .WithColumn("on_mannequin").AsBoolean().NotNullable()
+            .WithColumn("materia").AsCustom("jsonb").NotNullable()
+            .WithColumn("unit_price").AsInt32().NotNullable()
+            .WithColumn("quantity").AsInt32().NotNullable()
+            .WithColumn("dye_id").AsInt32().NotNullable()
+            .WithColumn("creator_id").AsString().Nullable()
+            .WithColumn("creator_name").AsString().Nullable()
+            .WithColumn("last_review_time").AsDateTimeOffset().NotNullable()
+            .WithColumn("retainer_id").AsString().NotNullable()
+            .WithColumn("retainer_name").AsString().NotNullable()
+            .WithColumn("retainer_city_id").AsInt32().Nullable()
+            .WithColumn("seller_id").AsString().NotNullable();
+
+        Create.Index()
+            .OnTable("listing")
+            .OnColumn("item_id")
+            .Ascending()
+            .OnColumn("world_id")
+            .Ascending()
+            .OnColumn("live")
+            .Ascending();
+    }
+
+    public override void Down()
+    {
+        Delete.Table("listing");
+    }
+}

--- a/src/Universalis.DbAccess/Queries/MarketBoard/ListingQuery.cs
+++ b/src/Universalis.DbAccess/Queries/MarketBoard/ListingQuery.cs
@@ -1,0 +1,8 @@
+﻿namespace Universalis.DbAccess.Queries.MarketBoard;
+
+public class ListingQuery
+{
+    public int ItemId { get; init; }
+
+    public int WorldId { get; init; }
+}

--- a/src/Universalis.DbAccess/Universalis.DbAccess.csproj
+++ b/src/Universalis.DbAccess/Universalis.DbAccess.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Npgsql" Version="7.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="Npgsql.Json.NET" Version="7.0.1" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/Universalis.DbAccess/Universalis.DbAccess.csproj
+++ b/src/Universalis.DbAccess/Universalis.DbAccess.csproj
@@ -7,9 +7,13 @@
 
   <ItemGroup>
     <PackageReference Include="CassandraCSharpDriver" Version="3.18.0" />
+    <PackageReference Include="FluentMigrator" Version="3.3.2" />
+    <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.3.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.0" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/Universalis.Entities/Character.cs
+++ b/src/Universalis.Entities/Character.cs
@@ -8,6 +8,10 @@ public class Character
 
     public int? WorldId { get; init; }
 
+    public Character()
+    {
+    }
+
     public Character(string contentIdSha256, string name, int? worldId)
     {
         ContentIdSha256 = contentIdSha256;

--- a/src/Universalis.Entities/MarketBoard/Listing.cs
+++ b/src/Universalis.Entities/MarketBoard/Listing.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Universalis.Entities.MarketBoard;
 
@@ -22,7 +23,7 @@ public class Listing
 
     public string CreatorName { get; set; }
 
-    public long LastReviewTimeUnixSeconds { get; set; }
+    public DateTime LastReviewTime { get; set; }
 
     public string RetainerId { get; set; }
 
@@ -31,4 +32,10 @@ public class Listing
     public int RetainerCityId { get; set; }
 
     public string SellerId { get; set; }
+    
+    public int ItemId { get; set; }
+    
+    public int WorldId { get; set; }
+    
+    public bool Live { get; set; }
 }


### PR DESCRIPTION
As listings are requested from Redis, they'll be added to Postgres if they aren't already there. New uploads will go straight to Postgres. Redis is still used for last upload times and upload applications, for now.

Old listings are not deleted, just hidden. I still need to experiment to see if deleting old listings immediately is performant, or if a cronjob is needed.