### PR TITLE
Implement workaround for empty listing IDs

### DIFF
--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -199,9 +199,12 @@ public class MarketBoardUploadBehavior : IUploadBehavior
         return uploadedListings
             .Select(l =>
             {
+                // Listing IDs from some uploaders are empty; this needs to be fixed
+                // but this should be a decent workaround that still enables data
+                // collection.
                 return new Listing
                 {
-                    ListingId = l.ListingId ?? "",
+                    ListingId = l.ListingId ?? $"dirty:{Guid.NewGuid()}",
                     ItemId = itemId,
                     WorldId = worldId,
                     Hq = Util.ParseUnusualBool(l.Hq),

--- a/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
@@ -120,6 +120,14 @@ public class CurrentlyShownStore : ICurrentlyShownStore
                         // be added back separately.
                         l.ItemId = itemId;
                         l.WorldId = worldId;
+
+                        if (string.IsNullOrEmpty(l.ListingId))
+                        {
+                            // Listing IDs from some uploaders are empty; this needs to be fixed
+                            // but this should be a decent workaround.
+                            l.ListingId = $"dirty:{Guid.NewGuid()}";
+                        }
+                        
                         return l;
                     })
                     .ToList();


### PR DESCRIPTION
This breaks data migration, since many listing IDs are currently empty. The listing ID is the primary key for a listing entity.