### PR TITLE
Update database layer to support batching across worlds and items

### DIFF
--- a/src/Universalis.Application.Tests/Mocks/DbAccess/MarketBoard/MockCurrentlyShownDbAccess.cs
+++ b/src/Universalis.Application.Tests/Mocks/DbAccess/MarketBoard/MockCurrentlyShownDbAccess.cs
@@ -24,7 +24,15 @@ public class MockCurrentlyShownDbAccess : ICurrentlyShownDbAccess
             .FirstOrDefault(d => d.WorldId == query.WorldId && d.ItemId == query.ItemId));
     }
 
-    public async Task Update(CurrentlyShown document, CurrentlyShownQuery query, CancellationToken cancellationToken = default)
+    public Task<IEnumerable<CurrentlyShown>> RetrieveMany(CurrentlyShownManyQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_collection.Where(d =>
+            query.WorldIds.Contains(d.WorldId) && query.ItemIds.Contains(d.ItemId)));
+    }
+
+    public async Task Update(CurrentlyShown document, CurrentlyShownQuery query,
+        CancellationToken cancellationToken = default)
     {
         await Delete(query, cancellationToken);
         await Create(document, cancellationToken);

--- a/src/Universalis.Application.Tests/Mocks/DbAccess/MarketBoard/MockHistoryDbAccess.cs
+++ b/src/Universalis.Application.Tests/Mocks/DbAccess/MarketBoard/MockHistoryDbAccess.cs
@@ -15,7 +15,8 @@ public class MockHistoryDbAccess : IHistoryDbAccess
 
     public Task Create(History document, CancellationToken cancellationToken = default)
     {
-        return InsertSales(document.Sales, new HistoryQuery { WorldId = document.WorldId, ItemId = document.ItemId }, cancellationToken);
+        return InsertSales(document.Sales, new HistoryQuery { WorldId = document.WorldId, ItemId = document.ItemId },
+            cancellationToken);
     }
 
     public Task<History> Retrieve(HistoryQuery query, CancellationToken cancellationToken = default)
@@ -30,20 +31,23 @@ public class MockHistoryDbAccess : IHistoryDbAccess
         {
             return Task.FromResult<History>(null);
         }
-        
+
         return Task.FromResult(new History
         {
             WorldId = query.WorldId,
             ItemId = query.ItemId,
-            LastUploadTimeUnixMilliseconds = sales.Count == 0 ? 0 : new DateTimeOffset(sales[0].SaleTime).ToUnixTimeMilliseconds(),
+            LastUploadTimeUnixMilliseconds =
+                sales.Count == 0 ? 0 : new DateTimeOffset(sales[0].SaleTime).ToUnixTimeMilliseconds(),
             Sales = sales,
         });
     }
 
-    public async Task<IEnumerable<History>> RetrieveMany(HistoryManyQuery query, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<History>> RetrieveMany(HistoryManyQuery query,
+        CancellationToken cancellationToken = default)
     {
         return (await Task.WhenAll(query.WorldIds
-            .Select(worldId => Retrieve(new HistoryQuery { WorldId = worldId, ItemId = query.ItemId }, cancellationToken))))
+                .SelectMany(worldId => query.ItemIds.Select(itemId =>
+                    Retrieve(new HistoryQuery { WorldId = worldId, ItemId = itemId }, cancellationToken)))))
             .Where(o => o != null);
     }
 
@@ -53,7 +57,7 @@ public class MockHistoryDbAccess : IHistoryDbAccess
         {
             _collection[sale.Id] = sale;
         }
-        
+
         return Task.CompletedTask;
     }
 }

--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -54,7 +54,7 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         }
 
         var cached =
-            await Task.WhenAll(worldIds.Select(worldId => FetchCurrentlyShownData(worldId, itemId, cancellationToken)));
+            await Task.WhenAll(worldIds.Select(worldId => FetchData(worldId, itemId, cancellationToken)));
         var data = cached
             .Where(o => o != null)
             .ToList();
@@ -164,7 +164,7 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         return (resolved, view);
     }
 
-    private async Task<CurrentlyShownView> FetchCurrentlyShownData(int worldId, int itemId,
+    private async Task<CurrentlyShownView> FetchData(int worldId, int itemId,
         CancellationToken cancellationToken = default)
     {
         using var activity = Util.ActivitySource.StartActivity("CurrentlyShownBase.FetchData");

--- a/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Universalis.DbAccess.MarketBoard;
 using Xunit;
 using System.Linq;
+using Universalis.DbAccess.Queries.MarketBoard;
+using Universalis.Entities.MarketBoard;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
 
@@ -19,27 +22,28 @@ public class CurrentlyShownStoreTests : IClassFixture<DbFixture>
 #if DEBUG
     [Fact]
 #endif
-    public async Task SetData_Works()
+    public async Task Insert_Works()
     {
         var store = _fixture.Services.GetRequiredService<ICurrentlyShownStore>();
         var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(74, 2);
-        await store.SetData(currentlyShown);
+        await store.Insert(currentlyShown);
     }
 
 #if DEBUG
     [Fact]
 #endif
-    public async Task SetDataGetData_Works()
+    public async Task InsertRetrieve_Works()
     {
         var store = _fixture.Services.GetRequiredService<ICurrentlyShownStore>();
         var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(74, 3);
-        await store.SetData(currentlyShown);
-        var results = await store.GetData(74, 3);
+        await store.Insert(currentlyShown);
+        var results = await store.Retrieve(new CurrentlyShownQuery { WorldId = 74, ItemId = 3 });
 
         Assert.NotNull(results);
         Assert.Equal(currentlyShown.WorldId, results.WorldId);
         Assert.Equal(currentlyShown.ItemId, results.ItemId);
-        Assert.Equal(currentlyShown.LastUploadTimeUnixMilliseconds / 1000, results.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.Equal(currentlyShown.LastUploadTimeUnixMilliseconds / 1000,
+            results.LastUploadTimeUnixMilliseconds / 1000);
         Assert.Equal(currentlyShown.UploadSource, results.UploadSource);
         Assert.All(currentlyShown.Listings.OrderBy(l => l.PricePerUnit).Zip(results.Listings), pair =>
         {
@@ -67,15 +71,88 @@ public class CurrentlyShownStoreTests : IClassFixture<DbFixture>
 #if DEBUG
     [Fact]
 #endif
-    public async Task GetData_ReturnsEmpty_WhenMissing()
+    public async Task InsertRetrieveMany_Works()
     {
         var store = _fixture.Services.GetRequiredService<ICurrentlyShownStore>();
-        var results = await store.GetData(74, 4);
+        var itemIds = Enumerable.Range(100, 5).ToList();
+        var expectedCurrentlyShown = new Dictionary<int, CurrentlyShown>();
+
+        // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var itemId in itemIds)
+        {
+            var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(74, itemId);
+            expectedCurrentlyShown[itemId] = currentlyShown;
+            await store.Insert(currentlyShown);
+        }
+
+        var results = await store.RetrieveMany(new CurrentlyShownManyQuery
+            { WorldIds = new[] { 74 }, ItemIds = itemIds });
+        Assert.NotNull(results);
+
+        foreach (var (itemId, result) in itemIds.Zip(results))
+        {
+            Assert.NotNull(results);
+            Assert.Equal(expectedCurrentlyShown[itemId].WorldId, result.WorldId);
+            Assert.Equal(itemId, result.ItemId);
+            Assert.Equal(expectedCurrentlyShown[itemId].UploadSource, result.UploadSource);
+            Assert.All(expectedCurrentlyShown[itemId].Listings.OrderBy(l => l.PricePerUnit).Zip(result.Listings),
+                pair =>
+                {
+                    var (expected, actual) = pair;
+                    Assert.Equal(expected.ListingId, actual.ListingId);
+                    Assert.Equal(expected.Hq, actual.Hq);
+                    Assert.Equal(expected.OnMannequin, actual.OnMannequin);
+                    Assert.Equal(expected.PricePerUnit, actual.PricePerUnit);
+                    Assert.Equal(expected.Quantity, actual.Quantity);
+                    Assert.Equal(expected.RetainerName, actual.RetainerName);
+                    Assert.Equal(expected.RetainerId, actual.RetainerId);
+                    Assert.Equal(expected.RetainerCityId, actual.RetainerCityId);
+                    Assert.Equal(expected.DyeId, actual.DyeId);
+                    Assert.Equal(expected.CreatorId, actual.CreatorId);
+                    Assert.Equal(expected.CreatorName, actual.CreatorName);
+                    Assert.Equal(new DateTimeOffset(expected.LastReviewTime).ToUnixTimeSeconds(),
+                        new DateTimeOffset(actual.LastReviewTime).ToUnixTimeSeconds());
+                    Assert.Equal(DateTimeKind.Utc, actual.LastReviewTime.Kind);
+                    Assert.Equal(expected.SellerId, actual.SellerId);
+                    Assert.Equal(DateTimeKind.Utc, actual.UpdatedAt.Kind);
+                    Assert.Equal(expected.Source, actual.Source);
+                });
+        }
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task Retrieve_ReturnsEmpty_WhenMissing()
+    {
+        var store = _fixture.Services.GetRequiredService<ICurrentlyShownStore>();
+        var results = await store.Retrieve(new CurrentlyShownQuery { WorldId = 74, ItemId = 4 });
         Assert.NotNull(results);
         Assert.Equal(0, results.WorldId);
         Assert.Equal(0, results.ItemId);
         Assert.Equal(0, results.LastUploadTimeUnixMilliseconds);
         Assert.Equal("", results.UploadSource);
         Assert.Empty(results.Listings);
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task RetrieveMany_ReturnsSeveralEmpties_WhenMissing()
+    {
+        var store = _fixture.Services.GetRequiredService<ICurrentlyShownStore>();
+        var results = await store.RetrieveMany(new CurrentlyShownManyQuery
+            { WorldIds = new[] { 74 }, ItemIds = Enumerable.Range(200, 10) });
+        var resultsList = results.ToList();
+        Assert.NotNull(resultsList);
+        Assert.NotEmpty(resultsList);
+        Assert.All(resultsList, result =>
+        {
+            Assert.Equal(0, result.WorldId);
+            Assert.Equal(0, result.ItemId);
+            Assert.Equal(0, result.LastUploadTimeUnixMilliseconds);
+            Assert.Equal("", result.UploadSource);
+            Assert.Empty(result.Listings);
+        });
     }
 }

--- a/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Universalis.DbAccess.MarketBoard;
 using Universalis.DbAccess.Queries.MarketBoard;
+using Universalis.Entities.MarketBoard;
 using Xunit;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
@@ -64,7 +66,7 @@ public class ListingStoreTests : IClassFixture<DbFixture>
 #if DEBUG
     [Fact]
 #endif
-    public async Task UpsertLiveMultipleRetrieveLive_Works()
+    public async Task UpsertLiveRetrieveLiveMultiple_Works()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         for (var i = 0; i < 10; i++)
@@ -103,11 +105,74 @@ public class ListingStoreTests : IClassFixture<DbFixture>
 #if DEBUG
     [Fact]
 #endif
+    public async Task UpsertLiveRetrieveManyLive_Works()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        var expectedListings = new Dictionary<int, IList<Listing>>();
+        for (var i = 100; i < 105; i++)
+        {
+            var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, i);
+            await store.UpsertLive(currentlyShown.Listings);
+            expectedListings[i] = currentlyShown.Listings;
+        }
+
+        var results = await store.RetrieveManyLive(new ListingManyQuery
+            { ItemIds = Enumerable.Range(100, 105), WorldIds = new[] { 93 } });
+
+        Assert.NotNull(results);
+        for (var i = 100; i < 105; i++)
+        {
+            Assert.All(expectedListings[i].OrderBy(l => l.PricePerUnit).Zip(results[new WorldItemPair(93, i)]), pair =>
+            {
+                var (expected, actual) = pair;
+                Assert.Equal(expected.ListingId, actual.ListingId);
+                Assert.Equal(expected.ItemId, actual.ItemId);
+                Assert.Equal(expected.WorldId, actual.WorldId);
+                Assert.Equal(expected.Hq, actual.Hq);
+                Assert.Equal(expected.OnMannequin, actual.OnMannequin);
+                Assert.Equal(expected.PricePerUnit, actual.PricePerUnit);
+                Assert.Equal(expected.Quantity, actual.Quantity);
+                Assert.Equal(expected.RetainerName, actual.RetainerName);
+                Assert.Equal(expected.RetainerId, actual.RetainerId);
+                Assert.Equal(expected.RetainerCityId, actual.RetainerCityId);
+                Assert.Equal(expected.DyeId, actual.DyeId);
+                Assert.Equal(expected.CreatorId, actual.CreatorId);
+                Assert.Equal(expected.CreatorName, actual.CreatorName);
+                Assert.Equal(new DateTimeOffset(expected.LastReviewTime).ToUnixTimeSeconds(),
+                    new DateTimeOffset(actual.LastReviewTime).ToUnixTimeSeconds());
+                Assert.Equal(DateTimeKind.Utc, actual.LastReviewTime.Kind);
+                Assert.Equal(expected.SellerId, actual.SellerId);
+                Assert.Equal(DateTimeKind.Utc, actual.UpdatedAt.Kind);
+                Assert.Equal(expected.Source, actual.Source);
+            });
+        }
+    }
+
+#if DEBUG
+    [Fact]
+#endif
     public async Task RetrieveLive_ReturnsEmpty_WhenMissing()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         var results = await store.RetrieveLive(new ListingQuery { ItemId = 4, WorldId = 93 });
         Assert.NotNull(results);
         Assert.Empty(results);
+    }
+
+#if DEBUG
+    [Fact]
+#endif
+    public async Task RetrieveManyLive_ReturnsEmpty_WhenMissing()
+    {
+        var store = _fixture.Services.GetRequiredService<IListingStore>();
+        var results = await store.RetrieveManyLive(new ListingManyQuery
+            { ItemIds = Enumerable.Range(200, 210), WorldIds = new[] { 93 } });
+        Assert.NotNull(results);
+        Assert.All(results, kvp =>
+        {
+            var (_, value) = kvp;
+            Assert.NotNull(value);
+            Assert.Empty(value);
+        });
     }
 }

--- a/src/Universalis.DbAccess/MarketBoard/CurrentlyShownDbAccess.cs
+++ b/src/Universalis.DbAccess/MarketBoard/CurrentlyShownDbAccess.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.MarketBoard;
@@ -16,11 +17,16 @@ public class CurrentlyShownDbAccess : ICurrentlyShownDbAccess
 
     public Task<CurrentlyShown> Retrieve(CurrentlyShownQuery query, CancellationToken cancellationToken = default)
     {
-        return _store.GetData(query.WorldId, query.ItemId, cancellationToken);
+        return _store.Retrieve(query, cancellationToken);
+    }
+
+    public Task<IEnumerable<CurrentlyShown>> RetrieveMany(CurrentlyShownManyQuery query, CancellationToken cancellationToken = default)
+    {
+        return _store.RetrieveMany(query, cancellationToken);
     }
 
     public Task Update(CurrentlyShown document, CurrentlyShownQuery query, CancellationToken cancellationToken = default)
     {
-        return _store.SetData(document, cancellationToken);
+        return _store.Insert(document, cancellationToken);
     }
 }

--- a/src/Universalis.DbAccess/MarketBoard/HistoryDbAccess.cs
+++ b/src/Universalis.DbAccess/MarketBoard/HistoryDbAccess.cs
@@ -21,25 +21,29 @@ public class HistoryDbAccess : IHistoryDbAccess
 
     public async Task Create(History document, CancellationToken cancellationToken = default)
     {
-        await _marketItemStore.SetData(new MarketItem
+        await _marketItemStore.Insert(new MarketItem
         {
             WorldId = document.WorldId,
             ItemId = document.ItemId,
             LastUploadTime =
-                DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(document.LastUploadTimeUnixMilliseconds)).UtcDateTime,
+                DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(document.LastUploadTimeUnixMilliseconds))
+                    .UtcDateTime,
         }, cancellationToken);
         await _saleStore.InsertMany(document.Sales, cancellationToken);
     }
 
     public async Task<History> Retrieve(HistoryQuery query, CancellationToken cancellationToken = default)
     {
-        var marketItem = await _marketItemStore.GetData(query.WorldId, query.ItemId, cancellationToken);
+        var marketItem =
+            await _marketItemStore.Retrieve(new MarketItemQuery { ItemId = query.ItemId, WorldId = query.WorldId },
+                cancellationToken);
         if (marketItem == null)
         {
             return null;
         }
-        
-        var sales = await _saleStore.RetrieveBySaleTime(query.WorldId, query.ItemId, query.Count ?? 1000, cancellationToken: cancellationToken);
+
+        var sales = await _saleStore.RetrieveBySaleTime(query.WorldId, query.ItemId, query.Count ?? 1000,
+            cancellationToken: cancellationToken);
         return new History
         {
             WorldId = marketItem.WorldId,
@@ -49,16 +53,43 @@ public class HistoryDbAccess : IHistoryDbAccess
         };
     }
 
-    public async Task<IEnumerable<History>> RetrieveMany(HistoryManyQuery query, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<History>> RetrieveMany(HistoryManyQuery query,
+        CancellationToken cancellationToken = default)
     {
-        return (await Task.WhenAll(query.WorldIds
-            .Select(worldId => Retrieve(new HistoryQuery { WorldId = worldId, ItemId = query.ItemId, Count = query.Count }, cancellationToken))))
-            .Where(h => h != null);
+        var worldItemTuples = query.WorldIds.SelectMany(worldId =>
+                query.ItemIds.Select(itemId => (worldId, itemId)))
+            .ToList();
+
+        // Get upload times
+        var marketItems =
+            await _marketItemStore.RetrieveMany(
+                new MarketItemManyQuery { ItemIds = query.ItemIds, WorldIds = query.WorldIds },
+                cancellationToken);
+        var marketItemsList = marketItems.ToList();
+        var marketItemsDict = marketItemsList.ToDictionary(mi => (mi.WorldId, mi.ItemId), mi => mi);
+
+        // Get sales where an upload time is known
+        var sales = new Dictionary<(int, int), List<Sale>>();
+        foreach (var (worldId, itemId) in worldItemTuples.Where(marketItemsDict.ContainsKey))
+        {
+            sales[(worldId, itemId)] = (await _saleStore.RetrieveBySaleTime(worldId, itemId, query.Count ?? 1000,
+                cancellationToken: cancellationToken)).ToList();
+        }
+
+        return marketItemsList
+            .Select(mi => new History
+            {
+                WorldId = mi.WorldId,
+                ItemId = mi.ItemId,
+                LastUploadTimeUnixMilliseconds = new DateTimeOffset(mi.LastUploadTime).ToUnixTimeMilliseconds(),
+                Sales = sales[(mi.WorldId, mi.ItemId)].ToList(),
+            });
     }
 
-    public async Task InsertSales(IEnumerable<Sale> sales, HistoryQuery query, CancellationToken cancellationToken = default)
+    public async Task InsertSales(IEnumerable<Sale> sales, HistoryQuery query,
+        CancellationToken cancellationToken = default)
     {
-        await _marketItemStore.SetData(new MarketItem
+        await _marketItemStore.Insert(new MarketItem
         {
             WorldId = query.WorldId,
             ItemId = query.ItemId,

--- a/src/Universalis.DbAccess/MarketBoard/ICurrentlyShownDbAccess.cs
+++ b/src/Universalis.DbAccess/MarketBoard/ICurrentlyShownDbAccess.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.MarketBoard;
@@ -8,6 +9,8 @@ namespace Universalis.DbAccess.MarketBoard;
 public interface ICurrentlyShownDbAccess
 {
     public Task<CurrentlyShown> Retrieve(CurrentlyShownQuery query, CancellationToken cancellationToken = default);
+    
+    public Task<IEnumerable<CurrentlyShown>> RetrieveMany(CurrentlyShownManyQuery query, CancellationToken cancellationToken = default);
 
     public Task Update(CurrentlyShown document, CurrentlyShownQuery query, CancellationToken cancellationToken = default);
 }

--- a/src/Universalis.DbAccess/MarketBoard/ICurrentlyShownStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/ICurrentlyShownStore.cs
@@ -1,12 +1,17 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.MarketBoard;
 
 namespace Universalis.DbAccess.MarketBoard;
 
 public interface ICurrentlyShownStore
 {
-    Task<CurrentlyShown> GetData(int worldId, int itemId, CancellationToken cancellationToken = default);
+    Task Insert(CurrentlyShown data, CancellationToken cancellationToken = default);
 
-    Task SetData(CurrentlyShown data, CancellationToken cancellationToken = default);
+    Task<CurrentlyShown> Retrieve(CurrentlyShownQuery query, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<CurrentlyShown>> RetrieveMany(CurrentlyShownManyQuery query,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
@@ -11,4 +11,6 @@ public interface IListingStore
     Task UpsertLive(IEnumerable<Listing> listings, CancellationToken cancellationToken = default);
 
     Task<IEnumerable<Listing>> RetrieveLive(ListingQuery query, CancellationToken cancellationToken = default);
+    
+    Task<IDictionary<WorldItemPair, IList<Listing>>> RetrieveManyLive(ListingManyQuery query, CancellationToken cancellationToken = default);
 }

--- a/src/Universalis.DbAccess/MarketBoard/IMarketItemStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/IMarketItemStore.cs
@@ -1,12 +1,16 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Universalis.DbAccess.Queries.MarketBoard;
 using Universalis.Entities.MarketBoard;
 
 namespace Universalis.DbAccess.MarketBoard;
 
 public interface IMarketItemStore
 {
-    Task SetData(MarketItem marketItem, CancellationToken cancellationToken = default);
+    Task Insert(MarketItem marketItem, CancellationToken cancellationToken = default);
 
-    ValueTask<MarketItem> GetData(int worldId, int itemId, CancellationToken cancellationToken = default);
+    ValueTask<MarketItem> Retrieve(MarketItemQuery query, CancellationToken cancellationToken = default);
+    
+    ValueTask<IEnumerable<MarketItem>> RetrieveMany(MarketItemManyQuery query, CancellationToken cancellationToken = default);
 }

--- a/src/Universalis.DbAccess/Queries/MarketBoard/CurrentlyShownManyQuery.cs
+++ b/src/Universalis.DbAccess/Queries/MarketBoard/CurrentlyShownManyQuery.cs
@@ -2,11 +2,9 @@
 
 namespace Universalis.DbAccess.Queries.MarketBoard;
 
-public class HistoryManyQuery
+public class CurrentlyShownManyQuery
 {
     public IEnumerable<int> WorldIds { get; init; }
 
     public IEnumerable<int> ItemIds { get; init; }
-
-    public int? Count { get; init; }
 }

--- a/src/Universalis.DbAccess/Queries/MarketBoard/ListingManyQuery.cs
+++ b/src/Universalis.DbAccess/Queries/MarketBoard/ListingManyQuery.cs
@@ -2,11 +2,9 @@
 
 namespace Universalis.DbAccess.Queries.MarketBoard;
 
-public class HistoryManyQuery
+public class ListingManyQuery
 {
     public IEnumerable<int> WorldIds { get; init; }
-
+    
     public IEnumerable<int> ItemIds { get; init; }
-
-    public int? Count { get; init; }
 }

--- a/src/Universalis.DbAccess/Queries/MarketBoard/MarketItemManyQuery.cs
+++ b/src/Universalis.DbAccess/Queries/MarketBoard/MarketItemManyQuery.cs
@@ -2,11 +2,9 @@
 
 namespace Universalis.DbAccess.Queries.MarketBoard;
 
-public class HistoryManyQuery
+public class MarketItemManyQuery
 {
     public IEnumerable<int> WorldIds { get; init; }
 
     public IEnumerable<int> ItemIds { get; init; }
-
-    public int? Count { get; init; }
 }

--- a/src/Universalis.DbAccess/Queries/MarketBoard/MarketItemQuery.cs
+++ b/src/Universalis.DbAccess/Queries/MarketBoard/MarketItemQuery.cs
@@ -1,0 +1,8 @@
+﻿namespace Universalis.DbAccess.Queries.MarketBoard;
+
+public class MarketItemQuery
+{
+    public int ItemId { get; init; }
+
+    public int WorldId { get; init; }
+}

--- a/src/Universalis.DbAccess/WorldItemPair.cs
+++ b/src/Universalis.DbAccess/WorldItemPair.cs
@@ -1,0 +1,5 @@
+﻿namespace Universalis.DbAccess;
+
+public record struct WorldItemPair(int WorldId, int ItemId)
+{
+}


### PR DESCRIPTION
I didn't update SaleStore because it doesn't seem to be suffering from delays right now; that can be adjusted if needed later on.