### PR TITLE
update: modify listings from upsert model to replace model.

### DIFF
--- a/src/Universalis.DbAccess.Tests/AccessControl/ApiKeyStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/AccessControl/ApiKeyStoreTests.cs
@@ -6,7 +6,8 @@ using Universalis.Entities.AccessControl;
 
 namespace Universalis.DbAccess.Tests.AccessControl;
 
-public class ApiKeyStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class ApiKeyStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/CharacterStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/CharacterStoreTests.cs
@@ -5,7 +5,8 @@ using Xunit;
 
 namespace Universalis.DbAccess.Tests;
 
-public class CharacterStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class CharacterStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/DatabaseCollection.cs
+++ b/src/Universalis.DbAccess.Tests/DatabaseCollection.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Universalis.DbAccess.Tests
+{
+    [CollectionDefinition("Database collection")]
+    public class DatabaseCollection : ICollectionFixture<DbFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/src/Universalis.DbAccess.Tests/DbFixture.cs
+++ b/src/Universalis.DbAccess.Tests/DbFixture.cs
@@ -26,7 +26,7 @@ public class DbFixture : IAsyncLifetime
     {
         _scylla = new TestcontainersBuilder<TestcontainersContainer>()
             .WithName(Guid.NewGuid().ToString("D"))
-            .WithImage("scylladb/scylla:5.1.0")
+            .WithImage("scylladb/scylla:5.1.3")
             .WithExposedPort(9042)
             .WithPortBinding(9042)
             .WithCommand("--smp", "1", "--overprovisioned", "1", "--memory", "512M", "--alternator-port", "8000", "--alternator-write-isolation", "only_rmw_uses_lwt")
@@ -37,21 +37,21 @@ public class DbFixture : IAsyncLifetime
             .Build();
         _cache = new TestcontainersBuilder<TestcontainersContainer>()
             .WithName(Guid.NewGuid().ToString("D"))
-            .WithImage("redis:7.0.0")
+            .WithImage("redis:7.0.8")
             .WithPortBinding(6379, true)
             .WithCommand("redis-server", "--save", "", "--loglevel", "warning")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(6379))
             .Build();
         _redis = new TestcontainersBuilder<TestcontainersContainer>()
             .WithName(Guid.NewGuid().ToString("D"))
-            .WithImage("redis:7.0.0")
+            .WithImage("redis:7.0.8")
             .WithPortBinding(6379, true)
             .WithCommand("redis-server", "--save", "", "--loglevel", "warning")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(6379))
             .Build();
         _postgres = new TestcontainersBuilder<TestcontainersContainer>()
             .WithName(Guid.NewGuid().ToString("D"))
-            .WithImage("postgres:14.3")
+            .WithImage("postgres:14.6")
             .WithEnvironment("POSTGRES_USER", "universalis")
             .WithEnvironment("POSTGRES_PASSWORD", "universalis")
             .WithPortBinding(5432, true)

--- a/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/CurrentlyShownStoreTests.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
 
-public class CurrentlyShownStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class CurrentlyShownStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
@@ -23,21 +23,21 @@ public class ListingStoreTests
 #if DEBUG
     [Fact]
 #endif
-    public async Task UpsertLive_Works()
+    public async Task ReplaceLive_Works()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 2);
-        await store.UpsertLive(currentlyShown.Listings);
+        await store.ReplaceLive(currentlyShown.Listings);
     }
 
 #if DEBUG
     [Fact]
 #endif
-    public async Task UpsertLiveRetrieveLive_Works()
+    public async Task ReplaceLiveRetrieveLive_Works()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 3);
-        await store.UpsertLive(currentlyShown.Listings);
+        await store.ReplaceLive(currentlyShown.Listings);
         var results = await store.RetrieveLive(new ListingQuery { ItemId = 3, WorldId = 93 });
 
         Assert.NotNull(results);
@@ -67,13 +67,13 @@ public class ListingStoreTests
 #if DEBUG
     [Fact]
 #endif
-    public async Task UpsertLiveRetrieveLiveMultiple_Works()
+    public async Task ReplaceLiveRetrieveLiveMultiple_Works()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         for (var i = 0; i < 10; i++)
         {
             var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, 5);
-            await store.UpsertLive(currentlyShown.Listings);
+            await store.ReplaceLive(currentlyShown.Listings);
             var results = await store.RetrieveLive(new ListingQuery { ItemId = 5, WorldId = 93 });
 
             Assert.NotNull(results);
@@ -106,14 +106,14 @@ public class ListingStoreTests
 #if DEBUG
     [Fact]
 #endif
-    public async Task UpsertLiveRetrieveManyLive_Works()
+    public async Task ReplaceLiveRetrieveManyLive_Works()
     {
         var store = _fixture.Services.GetRequiredService<IListingStore>();
         var expectedListings = new Dictionary<int, IList<Listing>>();
         for (var i = 100; i < 105; i++)
         {
             var currentlyShown = SeedDataGenerator.MakeCurrentlyShown(93, i);
-            await store.UpsertLive(currentlyShown.Listings);
+            await store.ReplaceLive(currentlyShown.Listings);
             expectedListings[i] = currentlyShown.Listings;
         }
 

--- a/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/ListingStoreTests.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
 
-public class ListingStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class ListingStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/MarketBoard/MarketItemStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/MarketItemStoreTests.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
 
-public class MarketItemStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class MarketItemStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/MarketBoard/SaleStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/SaleStoreTests.cs
@@ -9,7 +9,8 @@ using System.Collections.Generic;
 
 namespace Universalis.DbAccess.Tests.MarketBoard;
 
-public class SaleStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class SaleStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/SeedDataGenerator.cs
+++ b/src/Universalis.DbAccess.Tests/SeedDataGenerator.cs
@@ -13,27 +13,38 @@ public static class SeedDataGenerator
     public static CurrentlyShown MakeCurrentlyShown(int worldId, int itemId, long? lastUploadTime = null, int maxStackSize = 999)
     {
         var rand = new Random();
+        var usedPrices = new List<int>();
         var t = lastUploadTime ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var listings = Enumerable.Range(0, 100)
-            .Select(_ => new Listing
+            .Select(_ =>
             {
-                ListingId = rand.NextInt64().ToString(),
-                Hq = rand.NextDouble() > 0.5,
-                OnMannequin = rand.NextDouble() > 0.5,
-                Materia = new List<Materia>(),
-                PricePerUnit = rand.Next(100, 60000),
-                Quantity = rand.Next(1, maxStackSize),
-                DyeId = (byte)rand.Next(0, 255),
-                CreatorId = rand.NextInt64().ToString(),
-                CreatorName = "Bingus Bongus",
-                LastReviewTime = DateTime.UtcNow - TimeSpan.FromSeconds(rand.Next(0, 360000)),
-                RetainerId = rand.NextInt64().ToString(),
-                RetainerName = "xpotato",
-                RetainerCityId = 0xA,
-                SellerId = rand.NextInt64().ToString(),
-                ItemId = itemId,
-                WorldId = worldId,
-                Source = "test runner",
+                var price = rand.Next(100, 60000);
+                while (usedPrices.Contains(price))
+                {
+                    price += 1;
+                }
+                usedPrices.Add(price);
+
+                return new Listing
+                {
+                    ListingId = rand.NextInt64().ToString(),
+                    Hq = rand.NextDouble() > 0.5,
+                    OnMannequin = rand.NextDouble() > 0.5,
+                    Materia = new List<Materia>(),
+                    PricePerUnit = price,
+                    Quantity = rand.Next(1, maxStackSize),
+                    DyeId = (byte)rand.Next(0, 255),
+                    CreatorId = rand.NextInt64().ToString(),
+                    CreatorName = "Bingus Bongus",
+                    LastReviewTime = DateTime.UtcNow - TimeSpan.FromSeconds(rand.Next(0, 360000)),
+                    RetainerId = rand.NextInt64().ToString(),
+                    RetainerName = "xpotato",
+                    RetainerCityId = 0xA,
+                    SellerId = rand.NextInt64().ToString(),
+                    ItemId = itemId,
+                    WorldId = worldId,
+                    Source = "test runner",
+                };
             })
             .ToList();
         return new CurrentlyShown

--- a/src/Universalis.DbAccess.Tests/Uploads/DailyUploadCountStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/Uploads/DailyUploadCountStoreTests.cs
@@ -5,7 +5,8 @@ using Xunit;
 
 namespace Universalis.DbAccess.Tests.Uploads;
 
-public class DailyUploadCountStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class DailyUploadCountStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess.Tests/Uploads/FlaggedUploaderStoreTests.cs
+++ b/src/Universalis.DbAccess.Tests/Uploads/FlaggedUploaderStoreTests.cs
@@ -6,7 +6,8 @@ using Universalis.Entities.Uploads;
 
 namespace Universalis.DbAccess.Tests.Uploads;
 
-public class FlaggedUploaderStoreTests : IClassFixture<DbFixture>
+[Collection("Database collection")]
+public class FlaggedUploaderStoreTests
 {
     private readonly DbFixture _fixture;
 

--- a/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/CurrentlyShownStore.cs
@@ -36,7 +36,7 @@ public class CurrentlyShownStore : ICurrentlyShownStore
         var lastUploadTime = data.LastUploadTimeUnixMilliseconds;
         var listings = data.Listings;
 
-        await _listingStore.UpsertLive(listings.Select(l =>
+        await _listingStore.ReplaceLive(listings.Select(l =>
         {
             l.ItemId = itemId;
             l.WorldId = worldId;

--- a/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/IListingStore.cs
@@ -8,7 +8,7 @@ namespace Universalis.DbAccess.MarketBoard;
 
 public interface IListingStore
 {
-    Task UpsertLive(IEnumerable<Listing> listings, CancellationToken cancellationToken = default);
+    Task ReplaceLive(IEnumerable<Listing> listings, CancellationToken cancellationToken = default);
 
     Task<IEnumerable<Listing>> RetrieveLive(ListingQuery query, CancellationToken cancellationToken = default);
     

--- a/src/Universalis.GameData.Tests/GameDataProviderTests.cs
+++ b/src/Universalis.GameData.Tests/GameDataProviderTests.cs
@@ -5,7 +5,7 @@ namespace Universalis.GameData.Tests;
 public class GameDataProviderTests
 {
     private const string SqPack = @"C:\Program Files (x86)\SquareEnix\FINAL FANTASY XIV - A Realm Reborn\game\sqpack";
-    
+
 #if DEBUG
     [Fact]
 #endif
@@ -13,7 +13,7 @@ public class GameDataProviderTests
     {
         ServiceUtils.CreateGameDataProvider(SqPack);
     }
-        
+
     [InlineData(44, "Anima")]
     [InlineData(74, "Coeurl")]
     [InlineData(82, "Mandragora")]
@@ -26,11 +26,11 @@ public class GameDataProviderTests
         var actualWorldName = gameData.AvailableWorlds()[worldId];
         Assert.Equal(expectedWorldName, actualWorldName);
     }
-        
+
     [InlineData("Anima", 44)]
     [InlineData("Coeurl", 74)]
     [InlineData("Mandragora", 82)]
-    
+
 #if DEBUG
     [Theory]
 #endif
@@ -40,12 +40,12 @@ public class GameDataProviderTests
         var actualWorldId = gameData.AvailableWorldsReversed()[worldName];
         Assert.Equal(expectedWorldId, actualWorldId);
     }
-        
+
     [InlineData(44, true)]
     [InlineData(74, true)]
     [InlineData(0, false)]
     [InlineData(1, false)]
-    
+
 #if DEBUG
     [Theory]
 #endif
@@ -56,12 +56,12 @@ public class GameDataProviderTests
         var actuallyContains = worldIds.Contains(worldId);
         Assert.Equal(expectedToContain, actuallyContains);
     }
-        
+
     [InlineData(26165, true)]
     [InlineData(30759, true)]
     [InlineData(0, false)]
     [InlineData(1, false)]
-    
+
 #if DEBUG
     [Theory]
 #endif
@@ -71,5 +71,22 @@ public class GameDataProviderTests
         var worldIds = gameData.MarketableItemIds();
         var actuallyContains = worldIds.Contains(itemId);
         Assert.Equal(expectedToContain, actuallyContains);
+    }
+
+    [InlineData(26165, 1)]
+    [InlineData(30759, 1)]
+    [InlineData(38953, 1)] // 6.3 items
+    [InlineData(38954, 1)] // 6.3 items
+    [InlineData(4551, 999)] // Stackable Item
+#if DEBUG
+    [Theory]
+#endif
+    public void MarketableItemStackSizes_Should_Only_Contain_Real_Stack_Sizes(int itemId, int expectedStackSize)
+    {
+        var gameData = ServiceUtils.CreateGameDataProvider(SqPack);
+        var worldIds = gameData.MarketableItemStackSizes();
+        var actuallyContains = worldIds.TryGetValue(itemId, out int stackSizeValue);
+        Assert.True(actuallyContains);
+        Assert.Equal(expectedStackSize, stackSizeValue);
     }
 }


### PR DESCRIPTION
MVCC allows us to have a transaction view concurrently modified for both
views (grabbing the stall content and inserting the fresh content). This
should prevent any issues with needing a post cleanup job; however, this
will cause use to have VACUUM and page fragmentation, so we should test
this more.