### PR TITLE
Take listing upload states from the WorldItemUpload sorted set

### DIFF
--- a/src/Universalis.DbAccess/Uploads/IWorldItemUploadStore.cs
+++ b/src/Universalis.DbAccess/Uploads/IWorldItemUploadStore.cs
@@ -1,13 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Universalis.DbAccess.Uploads;
 
 public interface IWorldItemUploadStore
 {
-    Task SetItem(int worldId, int id, double val);
+    Task SetItem(int worldId, int itemId, double val);
 
     Task<IList<KeyValuePair<int, double>>> GetMostRecent(int worldId, int stop = -1);
-    
+
     Task<IList<KeyValuePair<int, double>>> GetLeastRecent(int worldId, int stop = -1);
+
+    Task<double?> GetUploadTime(int worldId, int itemId);
 }

--- a/src/Universalis.DbAccess/Uploads/WorldItemUploadStore.cs
+++ b/src/Universalis.DbAccess/Uploads/WorldItemUploadStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using StackExchange.Redis;
@@ -15,31 +16,42 @@ public class WorldItemUploadStore : IWorldItemUploadStore
     {
         _redis = redis;
     }
-    
-    public async Task SetItem(int worldId, int id, double val)
+
+    public async Task SetItem(int worldId, int itemId, double val)
     {
         using var activity = Util.ActivitySource.StartActivity("WorldItemUploadStore.SetItem");
 
         var db = _redis.GetDatabase(RedisDatabases.Instance0.Stats);
-        await db.SortedSetAddAsync(GetRedisKey(worldId), new[] { new SortedSetEntry(id, val) }, flags: CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(GetRedisKey(worldId), new[] { new SortedSetEntry(itemId, val) },
+            flags: CommandFlags.FireAndForget);
     }
-    
+
     public async Task<IList<KeyValuePair<int, double>>> GetMostRecent(int worldId, int stop = -1)
     {
         using var activity = Util.ActivitySource.StartActivity("WorldItemUploadStore.GetMostRecent");
 
         var db = _redis.GetDatabase(RedisDatabases.Instance0.Stats);
-        var items = await db.SortedSetRangeByRankWithScoresAsync(GetRedisKey(worldId), stop: stop, order: Order.Descending);
+        var items = await db.SortedSetRangeByRankWithScoresAsync(GetRedisKey(worldId), stop: stop,
+            order: Order.Descending);
         return items.Select(i => new KeyValuePair<int, double>((int)i.Element, i.Score)).ToList();
     }
-    
+
     public async Task<IList<KeyValuePair<int, double>>> GetLeastRecent(int worldId, int stop = -1)
     {
         using var activity = Util.ActivitySource.StartActivity("WorldItemUploadStore.GetLeastRecent");
 
         var db = _redis.GetDatabase(RedisDatabases.Instance0.Stats);
-        var items = await db.SortedSetRangeByRankWithScoresAsync(GetRedisKey(worldId), stop: stop, order: Order.Ascending);
+        var items = await db.SortedSetRangeByRankWithScoresAsync(GetRedisKey(worldId), stop: stop,
+            order: Order.Ascending);
         return items.Select(i => new KeyValuePair<int, double>((int)i.Element, i.Score)).ToList();
+    }
+
+    public Task<double?> GetUploadTime(int worldId, int itemId)
+    {
+        using var activity = Util.ActivitySource.StartActivity("WorldItemUploadStore.GetUploadTime");
+
+        var db = _redis.GetDatabase(RedisDatabases.Instance0.Stats);
+        return db.SortedSetScoreAsync(GetRedisKey(worldId), itemId);
     }
 
     private static string GetRedisKey(int worldId)


### PR DESCRIPTION
This allows the entire Listings database in Redis to be decommissioned, freeing up the node for PostgreSQL.