### PR TITLE
Fix MarketItemStore RequestMany batching

### DIFF
--- a/src/Universalis.DbAccess/MarketBoard/MarketItemStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/MarketItemStore.cs
@@ -130,7 +130,7 @@ public class MarketItemStore : IMarketItemStore
 
                 batchesRead++;
                 await reader.NextResultAsync(cancellationToken);
-            } while (batchesRead != itemIds.Count);
+            } while (batchesRead != worldItemTuples.Count);
 
             return marketItemRecords;
         }


### PR DESCRIPTION
This should fix the function only returning as many worlds as there are items specified