### PR TITLE
Fix split uploads possibly breaking listings

### DIFF
--- a/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
@@ -293,18 +293,6 @@ public class MarketBoardUploadBehaviorTests
         var result = await test.Behavior.Execute(source, upload);
         Assert.Null(result);
 
-        var currentlyShown = await test.CurrentlyShown.Retrieve(new CurrentlyShownQuery
-        {
-            WorldId = upload.WorldId.Value,
-            ItemId = upload.ItemId.Value,
-        });
-
-        Assert.NotNull(currentlyShown);
-        Assert.Equal(upload.WorldId.Value, currentlyShown.WorldId);
-        Assert.Equal(upload.ItemId.Value, currentlyShown.ItemId);
-        Assert.NotNull(currentlyShown.Listings);
-        Assert.Empty(currentlyShown.Listings);
-
         var history = await test.History.Retrieve(new HistoryQuery
         {
             WorldId = upload.WorldId.Value,

--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -136,7 +136,6 @@ public class MarketBoardUploadBehavior : IUploadBehavior
             }
         }
 
-        List<Listing> newListings = null;
         if (parameters.Listings != null)
         {
             if (parameters.Listings.Any(l =>
@@ -147,7 +146,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                 return new BadRequestResult();
             }
 
-            newListings = CleanUploadedListings(parameters.Listings, itemId, worldId, source.Name);
+            var newListings = CleanUploadedListings(parameters.Listings, itemId, worldId, source.Name);
 
             var oldListings = existingCurrentlyShown?.Listings ?? new List<Listing>();
             var addedListings = newListings.Where(l => !oldListings.Contains(l)).ToList();
@@ -160,8 +159,8 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                     WorldId = worldId,
                     ItemId = itemId,
                     Listings = addedListings
-                            .Select(Util.ListingToView)
-                            .ToList(),
+                        .Select(Util.ListingToView)
+                        .ToList(),
                 }, cancellationToken);
             }
 
@@ -172,32 +171,32 @@ public class MarketBoardUploadBehavior : IUploadBehavior
                     WorldId = worldId,
                     ItemId = itemId,
                     Listings = removedListings
-                            .Select(Util.ListingToView)
-                            .ToList(),
+                        .Select(Util.ListingToView)
+                        .ToList(),
                 }, cancellationToken);
             }
-        }
 
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        var listings = newListings ?? existingCurrentlyShown?.Listings ?? new List<Listing>();
-        var document = new CurrentlyShown
-        {
-            WorldId = worldId,
-            ItemId = itemId,
-            LastUploadTimeUnixMilliseconds = now,
-            UploadSource = source.Name,
-            Listings = listings,
-        };
-        await _currentlyShownDb.Update(document, new CurrentlyShownQuery
-        {
-            WorldId = worldId,
-            ItemId = itemId,
-        }, cancellationToken);
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var document = new CurrentlyShown
+            {
+                WorldId = worldId,
+                ItemId = itemId,
+                LastUploadTimeUnixMilliseconds = now,
+                UploadSource = source.Name,
+                Listings = newListings,
+            };
+            await _currentlyShownDb.Update(document, new CurrentlyShownQuery
+            {
+                WorldId = worldId,
+                ItemId = itemId,
+            }, cancellationToken);
+        }
 
         return null;
     }
 
-    private static List<Listing> CleanUploadedListings(IEnumerable<Schema.Listing> uploadedListings, int itemId, int worldId, string sourceName)
+    private static List<Listing> CleanUploadedListings(IEnumerable<Schema.Listing> uploadedListings, int itemId,
+        int worldId, string sourceName)
     {
         using var activity = Util.ActivitySource.StartActivity("MarketBoardUploadBehavior.CleanUploadedListings");
 


### PR DESCRIPTION
It might be possible for a split sales/listings upload pair to cause listings to become inconsistent. If listings go through first, and then sales go through, the sales upload can pull old data and reinsert it after the listings upload completes.

This is convoluted behavior.