### PR TITLE
Temporarily block Dalamud from uploading sales

### DIFF
--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -109,7 +109,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
         var existingCurrentlyShown = await currentlyShownTask;
         var existingHistory = await existingHistoryTask;
 
-        if (parameters.Sales != null)
+        if (source.Name != "goat" && parameters.Sales != null)
         {
             if (parameters.Sales.Any(s =>
                     Util.HasHtmlTags(s.BuyerName) || Util.HasHtmlTags(s.SellerId) || Util.HasHtmlTags(s.BuyerId)))


### PR DESCRIPTION
I introduced a bug causing incorrect sales to be sent along which needs to be merged before re-enabling this.