### PR TITLE
Doc clarification on entries-to-return/listings-to-return parameters when multiple itemIDs may be queried at once

### DIFF
--- a/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
@@ -27,8 +27,8 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// </summary>
     /// <param name="itemIds">The item ID or comma-separated item IDs to retrieve data for.</param>
     /// <param name="worldDcRegion">The world, data center, or region to retrieve data for. This may be an ID or a name. Regions should be specified as Japan, Europe, North-America, Oceania, China, or 中国.</param>
-    /// <param name="listingsToReturn">The number of listings to return. By default, all listings will be returned.</param>
-    /// <param name="entriesToReturn">The number of recent history entries to return. By default, a maximum of 5 entries will be returned.</param>
+    /// <param name="listingsToReturn">The number of listings to return per item. By default, all listings will be returned.</param>
+    /// <param name="entriesToReturn">The number of recent history entries to return per item. By default, a maximum of 5 entries will be returned.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
     /// <param name="noGst">

--- a/src/Universalis.Application/Controllers/V1/HistoryController.cs
+++ b/src/Universalis.Application/Controllers/V1/HistoryController.cs
@@ -24,7 +24,7 @@ public class HistoryController : HistoryControllerBase
     /// </summary>
     /// <param name="itemIds">The item ID or comma-separated item IDs to retrieve data for.</param>
     /// <param name="worldDcRegion">The world or data center to retrieve data for. This may be an ID or a name. Regions should be specified as Japan, Europe, North-America, Oceania, China, or 中国.</param>
-    /// <param name="entriesToReturn">The number of entries to return. By default, this is set to 1800, but may be set to a maximum of 999999.</param>
+    /// <param name="entriesToReturn">The number of entries to return per item. By default, this is set to 1800, but may be set to a maximum of 999999.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
     /// <param name="cancellationToken"></param>

--- a/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
@@ -28,8 +28,8 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// </summary>
     /// <param name="itemIds">The item ID or comma-separated item IDs to retrieve data for.</param>
     /// <param name="worldDcRegion">The world, data center, or region to retrieve data for. This may be an ID or a name. Regions should be specified as Japan, Europe, North-America, Oceania, China, or 中国.</param>
-    /// <param name="listingsToReturn">The number of listings to return. By default, all listings will be returned.</param>
-    /// <param name="entriesToReturn">The number of recent history entries to return. By default, a maximum of 5 entries will be returned.</param>
+    /// <param name="listingsToReturn">The number of listings to return per item. By default, all listings will be returned.</param>
+    /// <param name="entriesToReturn">The number of recent history entries to return per item. By default, a maximum of 5 entries will be returned.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
     /// <param name="noGst">

--- a/src/Universalis.Application/Controllers/V2/HistoryController.cs
+++ b/src/Universalis.Application/Controllers/V2/HistoryController.cs
@@ -25,7 +25,7 @@ public class HistoryController : HistoryControllerBase
     /// </summary>
     /// <param name="itemIds">The item ID or comma-separated item IDs to retrieve data for.</param>
     /// <param name="worldDcRegion">The world or data center to retrieve data for. This may be an ID or a name. Regions should be specified as Japan, Europe, North-America, Oceania, China, or 中国.</param>
-    /// <param name="entriesToReturn">The number of entries to return. By default, this is set to 1800, but may be set to a maximum of 999999.</param>
+    /// <param name="entriesToReturn">The number of entries to return per item. By default, this is set to 1800, but may be set to a maximum of 999999.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
     /// <param name="cancellationToken"></param>


### PR DESCRIPTION
Added clarification to fields where it says it sets the number of entries/listings to return when multiple IDs can be queried, mean they're a limit per item ID specified and not per query.

e.g. from [Market Board Current Data ](https://docs.universalis.app/#market-board-current-data) :

**entries**
_string (query)_ `The number of recent history entries to return. By default, a maximum of 5 entries will be returned.`


Becomes:

**entries**
_string (query)_ `The number of recent history entries to return per item. By default, a maximum of 5 entries will be returned.`



Actually caused me confusion the first time I read it and forgot to do something about it until now...
Better late than never I guess😅 

I'm not familiar with C# XML documentation comments but I believe this is the way to update these parts of the docs both for v1 and v2:

- [Market Board Sale History](https://docs.universalis.app/#market-board-sale-history) 
- [Market Board Current Data ](https://docs.universalis.app/#market-board-current-data) 