### PR TITLE
Factor in quantity of items sold for velocity calculation

### DIFF
--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -443,7 +443,7 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
     private static float GetSaleVelocity(IEnumerable<SaleView> sales, long unixNowMs, long statsWithinMs)
     {
         return Statistics.VelocityPerDay(sales
-            .Select(s => s.TimestampUnixSeconds * 1000), unixNowMs, statsWithinMs);
+            .Select(s => (s.TimestampUnixSeconds * 1000, s.Quantity)), unixNowMs, statsWithinMs);
     }
 
     private static IDictionary<int, int> GetListingsDistribution(IEnumerable<ListingView> listings)

--- a/src/Universalis.Application/Controllers/HistoryControllerBase.cs
+++ b/src/Universalis.Application/Controllers/HistoryControllerBase.cs
@@ -101,11 +101,11 @@ public class HistoryControllerBase : WorldDcRegionControllerBase
             StackSizeHistogramHq = new SortedDictionary<int, int>(Statistics.GetDistribution(hqSales
                 .Select(s => s.Quantity))),
             SaleVelocity = Statistics.VelocityPerDay(history.Sales
-                .Select(s => s.TimestampUnixSeconds * 1000), now, statsWithin),
+                .Select(s => (s.TimestampUnixSeconds * 1000, s.Quantity)), now, statsWithin),
             SaleVelocityNq = Statistics.VelocityPerDay(nqSales
-                .Select(s => s.TimestampUnixSeconds * 1000), now, statsWithin),
+                .Select(s => (s.TimestampUnixSeconds * 1000, s.Quantity)), now, statsWithin),
             SaleVelocityHq = Statistics.VelocityPerDay(hqSales
-                .Select(s => s.TimestampUnixSeconds * 1000), now, statsWithin),
+                .Select(s => (s.TimestampUnixSeconds * 1000, s.Quantity)), now, statsWithin),
         });
     }
 }

--- a/src/Universalis.DataTransformations.Tests/StatisticsTests.cs
+++ b/src/Universalis.DataTransformations.Tests/StatisticsTests.cs
@@ -72,46 +72,45 @@ public class StatisticsTests
         var timestampsInWeek = GetTimestampsInWeek(now, rand.Next(0, 100)).ToList();
         var timestampsBeforeWeek = GetTimestampsBeforeWeek(rand.Next(0, 100));
         var velocity = Statistics.VelocityPerDay(timestampsInWeek.Concat(timestampsBeforeWeek), now, WeekLength);
-        Assert.Equal(timestampsInWeek.Count / 7.0f, velocity);
+        Assert.Equal(timestampsInWeek.Sum(t => t.Item2) / 7.0f, velocity);
     }
 
-    [Theory]
-    [InlineData(0, new long[] { })]
-    public void WeekVelocityPerDay_IsCorrect2(int expected, long[] timestamps)
+    [Fact]
+    public void WeekVelocityPerDay_IsCorrect2()
     {
         var now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-        var velocity = Statistics.VelocityPerDay(timestamps, now, WeekLength);
-        Assert.Equal(expected, velocity);
+        var velocity = Statistics.VelocityPerDay(Array.Empty<(long, int)>(), now, WeekLength);
+        Assert.Equal(0, velocity);
     }
 
-    private static IEnumerable<long> GetTimestampsInWeek(long now, int count)
+    private static IEnumerable<(long, int)> GetTimestampsInWeek(long now, int count)
     {
         var startOfWeek = now - WeekLength;
         var rand = new Random();
 
-        var timestamps = new List<long>();
+        var timestamps = new List<(long, int)>();
         for (var i = 0; i < count - 2; i++)
         {
-            timestamps.Add(startOfWeek + (long)Math.Truncate(rand.NextDouble() * WeekLength));
+            timestamps.Add((startOfWeek + (long)Math.Truncate(rand.NextDouble() * WeekLength), rand.Next(1, 100)));
         }
 
         // Ensure at least one timestamp exists for both the beginning and end of the week.
-        timestamps.Add(startOfWeek);
-        timestamps.Add(now);
+        timestamps.Add((startOfWeek, rand.Next(1, 100)));
+        timestamps.Add((now, rand.Next(1, 100)));
 
         return timestamps;
     }
 
-    private static IEnumerable<long> GetTimestampsBeforeWeek(int count)
+    private static IEnumerable<(long, int)> GetTimestampsBeforeWeek(int count)
     {
         var now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         var startOfWeek = now - WeekLength;
         var rand = new Random();
 
-        var timestamps = new List<long>();
+        var timestamps = new List<(long, int)>();
         for (var i = 0; i < count; i++)
         {
-            timestamps.Add((long)Math.Truncate(rand.NextDouble() * startOfWeek));
+            timestamps.Add(((long)Math.Truncate(rand.NextDouble() * startOfWeek), rand.Next(1, 100)));
         }
 
         return timestamps;

--- a/src/Universalis.DataTransformations/Statistics.fs
+++ b/src/Universalis.DataTransformations/Statistics.fs
@@ -22,15 +22,15 @@ type Statistics =
         dict (Seq.countBy (fun n -> n) numbers)
 
     /// <summary>
-    /// Calculates the average number of timestamps per day.
+    /// Calculates the average number of events per day.
     /// </summary>
-    /// <param name="timestampsMs">The sequence of millisecond timestamps to evaluate.</param>
+    /// <param name="timestampsMs">The amount of events and the time of their occurrence.</param>
     /// <param name="unixNow">The current time in milliseconds since the UNIX epoch.</param>
     /// <param name="period">The period to calculate over.</param>
-    static member VelocityPerDay(timestampsMs: seq<int64>, unixNow: int64, period: int64) =
-        let filtered = seq { for t in timestampsMs do if t >= unixNow - period then t }
+    static member VelocityPerDay(timestampsMs: seq<struct(int64*int)>, unixNow: int64, period: int64) =
+        let filtered = seq { for t, q in timestampsMs do if t >= unixNow - period then q }
         if Seq.length filtered = 0 || period = 0L then
             0f
         else
             let nDays = single period / 86400000f
-            single (Seq.length filtered) / nDays
+            single (Seq.sum filtered) / nDays


### PR DESCRIPTION
Velocity currently only shows the amount of sales per day but doesn't include the amount of items sold in total.

I believe this should be included either in `saleVelocity`, or if non-breaking as a new attribute.