### PR TITLE
Fix GST calculation and make GST a separate property of listings instead of adding it to the unit and total prices

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
@@ -52,11 +52,11 @@ public class CurrentlyShownControllerTests
     public async Task Controller_Get_Succeeds_SingleItem_World(string worldOrDc)
     {
         var test = TestResources.Create();
-        
+
         const int itemId = 5333;
         var document = SeedDataGenerator.MakeCurrentlyShown(74, itemId);
         await test.CurrentlyShown.Update(document, new CurrentlyShownQuery { WorldId = 74, ItemId = itemId });
-        
+
         var sales = SeedDataGenerator.MakeHistory(74, itemId).Sales;
         await test.History.InsertSales(sales, new HistoryQuery { WorldId = 74, ItemId = itemId });
 
@@ -73,16 +73,16 @@ public class CurrentlyShownControllerTests
     public async Task Controller_Get_Succeeds_MultiItem_World(string worldOrDc)
     {
         var test = TestResources.Create();
-        
+
         var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333);
         await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
-        
+
         var sales1 = SeedDataGenerator.MakeHistory(74, 5333).Sales;
         await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
 
         var document2 = SeedDataGenerator.MakeCurrentlyShown(74, 5);
         await test.CurrentlyShown.Update(document2, new CurrentlyShownQuery { WorldId = 74, ItemId = 5 });
-        
+
         var sales2 = SeedDataGenerator.MakeHistory(74, 5).Sales;
         await test.History.InsertSales(sales2, new HistoryQuery { WorldId = 74, ItemId = 5 });
 
@@ -97,8 +97,10 @@ public class CurrentlyShownControllerTests
         Assert.Equal(test.GameData.AvailableWorlds()[document1.WorldId], currentlyShown.WorldName);
         Assert.Null(currentlyShown.DcName);
 
-        AssertCurrentlyShownValidWorld(document1, sales1, currentlyShown.Items.First(item => item.Key == document1.ItemId).Value, test.GameData);
-        AssertCurrentlyShownValidWorld(document2, sales2, currentlyShown.Items.First(item => item.Key == document2.ItemId).Value, test.GameData);
+        AssertCurrentlyShownValidWorld(document1, sales1,
+            currentlyShown.Items.First(item => item.Key == document1.ItemId).Value, test.GameData);
+        AssertCurrentlyShownValidWorld(document2, sales2,
+            currentlyShown.Items.First(item => item.Key == document2.ItemId).Value, test.GameData);
     }
 
     [Theory]
@@ -111,13 +113,13 @@ public class CurrentlyShownControllerTests
 
         var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
         await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
-        
+
         var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
         await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
 
         var document2 = SeedDataGenerator.MakeCurrentlyShown(34, 5333, unixNowMs);
         await test.CurrentlyShown.Update(document2, new CurrentlyShownQuery { WorldId = 34, ItemId = 5333 });
-        
+
         var sales2 = SeedDataGenerator.MakeHistory(34, 5333, unixNowMs).Sales;
         await test.History.InsertSales(sales2, new HistoryQuery { WorldId = 34, ItemId = 5333 });
 
@@ -153,13 +155,13 @@ public class CurrentlyShownControllerTests
 
         var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
         await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
-        
+
         var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
         await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
 
         var document2 = SeedDataGenerator.MakeCurrentlyShown(34, 5, unixNowMs);
         await test.CurrentlyShown.Update(document2, new CurrentlyShownQuery { WorldId = 34, ItemId = 5 });
-        
+
         var sales2 = SeedDataGenerator.MakeHistory(34, 5, unixNowMs).Sales;
         await test.History.InsertSales(sales2, new HistoryQuery { WorldId = 34, ItemId = 5 });
 
@@ -361,16 +363,20 @@ public class CurrentlyShownControllerTests
 
         var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
         await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
-        
+
         var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
         await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
 
-        var result = await test.Controller.Get("5333", "Crystal", fields: "listings.pricePerUnit,minPrice,recentHistory");
+        var result =
+            await test.Controller.Get("5333", "Crystal", fields: "listings.pricePerUnit,minPrice,recentHistory");
         var currentlyShown = (CurrentlyShownView)Assert.IsType<OkObjectResult>(result).Value;
 
-        var json = JsonSerializer.Serialize(currentlyShown, new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
+        var json = JsonSerializer.Serialize(currentlyShown,
+            new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
 
-        Assert.Matches(@"{""listings"":\[({""pricePerUnit"":\d+},?){100}],""recentHistory"":\[({""hq"":(false|true),""pricePerUnit"":\d+,""quantity"":\d+,""timestamp"":\d+,""worldName"":""Coeurl"",""worldID"":74,""buyerName"":null,""total"":\d+},?){5}],""minPrice"":\d+}", json);
+        Assert.Matches(
+            @"{""listings"":\[({""pricePerUnit"":\d+},?){100}],""recentHistory"":\[({""hq"":(false|true),""pricePerUnit"":\d+,""quantity"":\d+,""timestamp"":\d+,""worldName"":""Coeurl"",""worldID"":74,""buyerName"":null,""total"":\d+},?){5}],""minPrice"":\d+}",
+            json);
     }
 
     [Fact]
@@ -381,30 +387,36 @@ public class CurrentlyShownControllerTests
 
         var document1 = SeedDataGenerator.MakeCurrentlyShown(74, 5333, unixNowMs);
         await test.CurrentlyShown.Update(document1, new CurrentlyShownQuery { WorldId = 74, ItemId = 5333 });
-        
+
         var sales1 = SeedDataGenerator.MakeHistory(74, 5333, unixNowMs).Sales;
         await test.History.InsertSales(sales1, new HistoryQuery { WorldId = 74, ItemId = 5333 });
 
         var document2 = SeedDataGenerator.MakeCurrentlyShown(34, 5, unixNowMs);
         await test.CurrentlyShown.Update(document2, new CurrentlyShownQuery { WorldId = 34, ItemId = 5 });
-        
+
         var sales2 = SeedDataGenerator.MakeHistory(34, 5, unixNowMs).Sales;
         await test.History.InsertSales(sales2, new HistoryQuery { WorldId = 34, ItemId = 5 });
 
-        var result = await test.Controller.Get("5,5333", "Crystal", fields: "items.listings.pricePerUnit,dcName,items.minPrice");
+        var result = await test.Controller.Get("5,5333", "Crystal",
+            fields: "items.listings.pricePerUnit,dcName,items.minPrice");
         var currentlyShown = (CurrentlyShownMultiViewV2)Assert.IsType<OkObjectResult>(result).Value;
 
-        var json = JsonSerializer.Serialize(currentlyShown, new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
+        var json = JsonSerializer.Serialize(currentlyShown,
+            new JsonSerializerOptions { Converters = { new PartiallySerializableJsonConverterFactory() } });
 
-        Assert.Matches(@"{""items"":{""5"":{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+},""5333"":{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+}},""dcName"":""Crystal""}", json);
+        Assert.Matches(
+            @"{""items"":{""5"":{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+},""5333"":{""listings"":\[({""pricePerUnit"":\d+},?){100}],""minPrice"":\d+}},""dcName"":""Crystal""}",
+            json);
     }
 
-    private static void AssertCurrentlyShownValidWorld(CurrentlyShown document, List<Sale> sales, CurrentlyShownView currentlyShown, IGameDataProvider gameData)
+    private static void AssertCurrentlyShownValidWorld(CurrentlyShown document, List<Sale> sales,
+        CurrentlyShownView currentlyShown, IGameDataProvider gameData)
     {
         Assert.Equal(document.ItemId, currentlyShown.ItemId);
         Assert.Equal(document.WorldId, currentlyShown.WorldId);
         Assert.Equal(gameData.AvailableWorlds()[document.WorldId], currentlyShown.WorldName);
-        Assert.Equal(document.LastUploadTimeUnixMilliseconds / 1000, currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.Equal(document.LastUploadTimeUnixMilliseconds / 1000,
+            currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
         Assert.Null(currentlyShown.DcName);
 
         Assert.NotNull(currentlyShown.Listings);
@@ -415,20 +427,14 @@ public class CurrentlyShownControllerTests
         document.Listings.Sort((a, b) => b.PricePerUnit - a.PricePerUnit);
         sales.Sort((a, b) => (int)(b.SaleTime - a.SaleTime).TotalMilliseconds);
 
-        var listings = document.Listings.Select(l =>
-        {
-            l.PricePerUnit = (int)Math.Ceiling(l.PricePerUnit * 1.05);
-            return l;
-        }).ToList();
-
         Assert.All(currentlyShown.Listings.Select(l => (object)l.WorldId), Assert.Null);
         Assert.All(currentlyShown.Listings.Select(l => l.WorldName), Assert.Null);
 
         Assert.All(currentlyShown.RecentHistory.Select(s => (object)s.WorldId), Assert.Null);
         Assert.All(currentlyShown.RecentHistory.Select(s => s.WorldName), Assert.Null);
 
-        var nqListings = listings.Where(s => !s.Hq).ToList();
-        var hqListings = listings.Where(s => s.Hq).ToList();
+        var nqListings = currentlyShown.Listings.Where(s => !s.Hq).ToList();
+        var hqListings = currentlyShown.Listings.Where(s => s.Hq).ToList();
 
         Assert.True(currentlyShown.CurrentAveragePrice > 0);
         Assert.True(currentlyShown.CurrentAveragePriceNq > 0);
@@ -458,19 +464,25 @@ public class CurrentlyShownControllerTests
         Assert.True(currentlyShown.SaleVelocityNq > 0);
         Assert.True(currentlyShown.SaleVelocityHq > 0);
 
-        var stackSizeHistogram = new SortedDictionary<int, int>(Statistics.GetDistribution(listings.Select(l => l.Quantity)));
-        var stackSizeHistogramNq = new SortedDictionary<int, int>(Statistics.GetDistribution(nqListings.Select(l => l.Quantity)));
-        var stackSizeHistogramHq = new SortedDictionary<int, int>(Statistics.GetDistribution(hqListings.Select(l => l.Quantity)));
+        var stackSizeHistogram =
+            new SortedDictionary<int, int>(Statistics.GetDistribution(currentlyShown.Listings.Select(l => l.Quantity)));
+        var stackSizeHistogramNq =
+            new SortedDictionary<int, int>(Statistics.GetDistribution(nqListings.Select(l => l.Quantity)));
+        var stackSizeHistogramHq =
+            new SortedDictionary<int, int>(Statistics.GetDistribution(hqListings.Select(l => l.Quantity)));
 
         Assert.Equal(stackSizeHistogram, currentlyShown.StackSizeHistogram);
         Assert.Equal(stackSizeHistogramNq, currentlyShown.StackSizeHistogramNq);
         Assert.Equal(stackSizeHistogramHq, currentlyShown.StackSizeHistogramHq);
 
-        Assert.Equal(document.Listings.Take(currentlyShown.Listings.Count).Sum(listing => listing.Quantity), currentlyShown.UnitsForSale);
-        Assert.Equal(sales.Take(currentlyShown.RecentHistory.Count).Sum(sale => sale.Quantity), currentlyShown.UnitsSold);
+        Assert.Equal(document.Listings.Take(currentlyShown.Listings.Count).Sum(listing => listing.Quantity),
+            currentlyShown.UnitsForSale);
+        Assert.Equal(sales.Take(currentlyShown.RecentHistory.Count).Sum(sale => sale.Quantity),
+            currentlyShown.UnitsSold);
     }
 
-    private static void AssertCurrentlyShownDataCenter(CurrentlyShown anyWorldDocument, List<Sale> sales, CurrentlyShownView currentlyShown, long lastUploadTime, string worldOrDc)
+    private static void AssertCurrentlyShownDataCenter(CurrentlyShown anyWorldDocument, List<Sale> sales,
+        CurrentlyShownView currentlyShown, long lastUploadTime, string worldOrDc)
     {
         Assert.Equal(anyWorldDocument.ItemId, currentlyShown.ItemId);
         Assert.Equal(lastUploadTime / 1000, currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
@@ -486,20 +498,14 @@ public class CurrentlyShownControllerTests
         anyWorldDocument.Listings.Sort((a, b) => b.PricePerUnit - a.PricePerUnit);
         sales.Sort((a, b) => (int)(b.SaleTime - a.SaleTime).TotalMilliseconds);
 
-        var listings = anyWorldDocument.Listings.Select(l =>
-        {
-            l.PricePerUnit = (int)Math.Ceiling(l.PricePerUnit * 1.05);
-            return l;
-        }).ToList();
-
         Assert.All(currentlyShown.Listings.Select(l => (object)l.WorldId), Assert.NotNull);
         Assert.All(currentlyShown.Listings.Select(l => l.WorldName), Assert.NotNull);
 
         Assert.All(currentlyShown.RecentHistory.Select(s => (object)s.WorldId), Assert.NotNull);
         Assert.All(currentlyShown.RecentHistory.Select(s => s.WorldName), Assert.NotNull);
 
-        var nqListings = listings.Where(s => !s.Hq).ToList();
-        var hqListings = listings.Where(s => s.Hq).ToList();
+        var nqListings = anyWorldDocument.Listings.Where(s => !s.Hq).ToList();
+        var hqListings = anyWorldDocument.Listings.Where(s => s.Hq).ToList();
 
         Assert.True(currentlyShown.CurrentAveragePrice > 0);
         Assert.True(currentlyShown.CurrentAveragePriceNq > 0);
@@ -529,9 +535,13 @@ public class CurrentlyShownControllerTests
         Assert.True(currentlyShown.SaleVelocityNq > 0);
         Assert.True(currentlyShown.SaleVelocityHq > 0);
 
-        var stackSizeHistogram = new SortedDictionary<int, int>(Statistics.GetDistribution(listings.Select(l => l.Quantity)));
-        var stackSizeHistogramNq = new SortedDictionary<int, int>(Statistics.GetDistribution(nqListings.Select(l => l.Quantity)));
-        var stackSizeHistogramHq = new SortedDictionary<int, int>(Statistics.GetDistribution(hqListings.Select(l => l.Quantity)));
+        var stackSizeHistogram =
+            new SortedDictionary<int, int>(
+                Statistics.GetDistribution(anyWorldDocument.Listings.Select(l => l.Quantity)));
+        var stackSizeHistogramNq =
+            new SortedDictionary<int, int>(Statistics.GetDistribution(nqListings.Select(l => l.Quantity)));
+        var stackSizeHistogramHq =
+            new SortedDictionary<int, int>(Statistics.GetDistribution(hqListings.Select(l => l.Quantity)));
 
         Assert.Equal(stackSizeHistogram, currentlyShown.StackSizeHistogram);
         Assert.Equal(stackSizeHistogramNq, currentlyShown.StackSizeHistogramNq);

--- a/src/Universalis.Application.Tests/UtilTests.cs
+++ b/src/Universalis.Application.Tests/UtilTests.cs
@@ -6,6 +6,20 @@ namespace Universalis.Application.Tests;
 public class UtilTests
 {
     [Theory]
+    [InlineData(1, 1, 0)]
+    [InlineData(1, 13, 0)]
+    [InlineData(9, 23, 10)]
+    [InlineData(9999, 1, 499)]
+    [InlineData(10000, 1, 500)]
+    [InlineData(189972, 1, 9498)]
+    [InlineData(200, 55, 550)]
+    public void CalculateTax_Works(int unitPrice, int quantity, int expected)
+    {
+        var actual = Util.CalculateTax(unitPrice, quantity);
+        Assert.Equal(expected, actual);
+    }
+    
+    [Theory]
     [InlineData("{\"Hq\":true}", true)]
     [InlineData("{\"Hq\":false}", false)]
     [InlineData("{\"Hq\":\"true\"}", true)]

--- a/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
+++ b/src/Universalis.Application/Controllers/CurrentlyShownControllerBase.cs
@@ -32,7 +32,6 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         int itemId,
         int nListings = int.MaxValue,
         int nEntries = int.MaxValue,
-        bool noGst = false,
         bool? onlyHq = null,
         long statsWithin = 604800000,
         long entriesWithin = -1,
@@ -46,11 +45,11 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
 
         if (worldIds.Length == 1)
         {
-            return await GetView(worldDcRegion, worldIds[0], itemId, nListings, nEntries, noGst, onlyHq, statsWithin,
+            return await GetView(worldDcRegion, worldIds[0], itemId, nListings, nEntries, onlyHq, statsWithin,
                 entriesWithin, fields, cancellationToken);
         }
 
-        return await GetViewBatched(worldDcRegion, worldIds, itemId, nListings, nEntries, noGst, onlyHq, statsWithin,
+        return await GetViewBatched(worldDcRegion, worldIds, itemId, nListings, nEntries, onlyHq, statsWithin,
             entriesWithin, fields, cancellationToken);
     }
 
@@ -60,7 +59,6 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         int itemId,
         int nListings = int.MaxValue,
         int nEntries = int.MaxValue,
-        bool noGst = false,
         bool? onlyHq = null,
         long statsWithin = 604800000,
         long entriesWithin = -1,
@@ -107,12 +105,7 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         currentlyShown.Listings = currentlyShown.Listings
             .Select(l =>
             {
-                if (!noGst)
-                {
-                    l.PricePerUnit = (int)Math.Ceiling(l.PricePerUnit * 1.05);
-                    l.Total = (int)Math.Ceiling(l.Total * 1.05);
-                }
-
+                l.Tax = Util.CalculateTax(l.PricePerUnit, l.Quantity);
                 l.WorldId = null;
                 l.WorldName = null;
                 l.SerializableProperties = listingSerializableProperties;
@@ -189,7 +182,6 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
         int itemId,
         int nListings = int.MaxValue,
         int nEntries = int.MaxValue,
-        bool noGst = false,
         bool? onlyHq = null,
         long statsWithin = 604800000,
         long entriesWithin = -1,
@@ -244,12 +236,7 @@ public class CurrentlyShownControllerBase : WorldDcRegionControllerBase
                     aggData.Listings.AddRange(next.Listings
                         .Select(l =>
                         {
-                            if (!noGst)
-                            {
-                                l.PricePerUnit = (int)Math.Ceiling(l.PricePerUnit * 1.05);
-                                l.Total = (int)Math.Ceiling(l.Total * 1.05);
-                            }
-
+                            l.Tax = Util.CalculateTax(l.PricePerUnit, l.Quantity);
                             l.WorldId = !worldDcRegion.IsWorld ? next.WorldId : null;
                             l.WorldName = !worldDcRegion.IsWorld ? worlds[next.WorldId.Value] : null;
                             l.SerializableProperties = listingSerializableProperties;

--- a/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V1/CurrentlyShownController.cs
@@ -31,11 +31,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// <param name="entriesToReturn">The number of recent history entries to return per item. By default, a maximum of 5 entries will be returned.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
-    /// <param name="noGst">
-    /// If the result should not have Gil sales tax (GST) factored in. GST is applied to all
-    /// consumer purchases in-game, and is separate from the retainer city tax that impacts what sellers receive.
-    /// By default, GST is factored in. Set this parameter to true or 1 to prevent this.
-    /// </param>
     /// <param name="hq">Filter for HQ listings and entries. By default, both HQ and NQ listings and entries will be returned.</param>
     /// <param name="fields">
     /// A comma separated list of fields that should be included in the response, if omitted will return all fields.
@@ -58,7 +53,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         string worldDcRegion,
         [FromQuery(Name = "listings")] string listingsToReturn = "",
         [FromQuery(Name = "entries")] string entriesToReturn = "",
-        [FromQuery] string noGst = "",
         [FromQuery] string hq = "",
         [FromQuery] string statsWithin = "",
         [FromQuery] string entriesWithin = "",
@@ -115,7 +109,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
             entriesWithinSeconds = Math.Max(0, queryEntriesWithinSeconds);
         }
 
-        var noGstBool = Util.ParseUnusualBool(noGst);
         bool? hqBool = string.IsNullOrEmpty(hq) || hq.ToLowerInvariant() == "null" ? null : Util.ParseUnusualBool(hq);
 
         var serializableProperties = BuildSerializableProperties(InputProcessing.ParseFields(fields));
@@ -134,7 +127,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
             }
 
             var (_, currentlyShownView) = await GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, hqBool, statsWithinMs, entriesWithinSeconds,
                 serializableProperties,
                 cts.Token);
             return Ok(currentlyShownView);
@@ -144,7 +137,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         var itemsSerializableProperties = BuildSerializableProperties(serializableProperties, "items");
         var currentlyShownViewTasks = itemIdsArray
             .Select(itemId => GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, hqBool, statsWithinMs, entriesWithinSeconds,
                 itemsSerializableProperties,
                 cts.Token))
             .ToList();

--- a/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
+++ b/src/Universalis.Application/Controllers/V2/CurrentlyShownController.cs
@@ -32,11 +32,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
     /// <param name="entriesToReturn">The number of recent history entries to return per item. By default, a maximum of 5 entries will be returned.</param>
     /// <param name="statsWithin">The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.</param>
     /// <param name="entriesWithin">The amount of time before now to take entries within, in seconds. Negative values will be ignored.</param>
-    /// <param name="noGst">
-    /// If the result should not have Gil sales tax (GST) factored in. GST is applied to all
-    /// consumer purchases in-game, and is separate from the retainer city tax that impacts what sellers receive.
-    /// By default, GST is factored in. Set this parameter to true or 1 to prevent this.
-    /// </param>
     /// <param name="hq">Filter for HQ listings and entries. By default, both HQ and NQ listings and entries will be returned.</param>
     /// <param name="fields">
     /// A comma separated list of fields that should be included in the response, if omitted will return all fields.
@@ -59,7 +54,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         string worldDcRegion,
         [FromQuery(Name = "listings")] string listingsToReturn = "",
         [FromQuery(Name = "entries")] string entriesToReturn = "",
-        [FromQuery] string noGst = "",
         [FromQuery] string hq = "",
         [FromQuery] string statsWithin = "",
         [FromQuery] string entriesWithin = "",
@@ -118,7 +112,6 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
 
         var serializableProperties = BuildSerializableProperties(InputProcessing.ParseFields(fields));
 
-        var noGstBool = Util.ParseUnusualBool(noGst);
         bool? hqBool = string.IsNullOrEmpty(hq) || hq.ToLowerInvariant() == "null" ? null : Util.ParseUnusualBool(hq);
 
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -134,7 +127,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
             }
 
             var (_, currentlyShownView) = await GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, hqBool, statsWithinMs, entriesWithinSeconds,
                 serializableProperties,
                 cts.Token);
             return Ok(currentlyShownView);
@@ -144,7 +137,7 @@ public class CurrentlyShownController : CurrentlyShownControllerBase
         var itemsSerializableProperties = BuildSerializableProperties(serializableProperties, "items");
         var currentlyShownViewTasks = itemIdsArray
             .Select(itemId => GetCurrentlyShownView(
-                worldDc, worldIds, itemId, nListings, nEntries, noGstBool, hqBool, statsWithinMs, entriesWithinSeconds,
+                worldDc, worldIds, itemId, nListings, nEntries, hqBool, statsWithinMs, entriesWithinSeconds,
                 itemsSerializableProperties,
                 cts.Token))
             .ToList();

--- a/src/Universalis.Application/Util.cs
+++ b/src/Universalis.Application/Util.cs
@@ -27,6 +27,12 @@ public static partial class Util
     [GeneratedRegex("[^a-zA-Z0-9'\\- ·⺀-⺙⺛-⻳⼀-⿕々〇〡-〩〸-〺〻㐀-䶵一-鿃豈-鶴侮-頻並-龎]", RegexOptions.Compiled)]
     private static partial Regex UnsafeCharactersRegex();
 
+    public static int CalculateTax(int unitPrice, int quantity)
+    {
+        const double taxRate = 0.05;
+        return (int)Math.Floor(quantity * unitPrice * taxRate);
+    }
+
     public static SaleView SaleToView(Sale s)
     {
         var quantity = s.Quantity ?? 0;

--- a/src/Universalis.Application/Views/V1/ListingView.cs
+++ b/src/Universalis.Application/Views/V1/ListingView.cs
@@ -149,6 +149,13 @@ public class ListingView : PartiallySerializable, IPriceable, ICopyable
     [JsonPropertyName("total")]
     public int Total { get; set; }
 
+    /// <summary>
+    /// The Gil sales tax (GST) to be added to the total price during purchase.
+    /// </summary>
+    [BsonElement("tax")]
+    [JsonPropertyName("tax")]
+    public int Tax { get; set; }
+
     public ICopyable Clone()
     {
         return (ListingView)MemberwiseClone();


### PR DESCRIPTION
This PR fixes how GST is calculated and makes it not precalculated in the unit/total prices of listing objects by default. Previously, the API calculated the GST of a listing's total price as `ceil(pq * 1.05)`, where `p` is the unit price and `q` is the quantity of the item. For GST of the unit price, the calculation done was `ceil(p * 1.05)`. Test cases have been added for tax calculation.

How the API should compute unit GST is open to interpretation, as the game itself never does this - it only computes GST over the total price.

Either way, the API's behavior was incorrect for two reasons:
1. If the API does compute GST for unit prices, it should do so by dividing the total tax by the quantity of the item sold, and returning the result as an exact (non-rounded) value. I did not want to do that because it would have required making unit price a decimal value, which would break the API contract in a way that would cause runtime errors for consumers using programming languages that distinguish between integers and floating-point numbers.
2. The formula itself was incorrect. The correct formula for the taxed total price is `pq + floor(pq * 0.05)` (thanks DioKi for figuring this out!). This means that the unit GST should be `(pq + floor(pq * 0.05)) / q`.

To correct this without breaking the API contract as much, I decided to remove the `noGst` parameter on the current data endpoints and instead introduce a new listing property called `tax`, which represents the amount that will be added to the total price when the listing is purchased. This value is calculated as `floor(pq * 0.05)`. The unit GST is completely removed, though API consumers can choose to factor it into their own formulas if desired, by adding `tax / q` to the unit price.