### PR TITLE
Declare query idempotence in DataStax driver by default

### DIFF
--- a/src/Universalis.DbAccess/DbAccessExtensions.cs
+++ b/src/Universalis.DbAccess/DbAccessExtensions.cs
@@ -54,9 +54,12 @@ public static class DbAccessExtensions
 
         MappingConfiguration.Global.Define<ObjectMappings>();
 
+        // Notes on query idempotence and speculative execution: https://docs.datastax.com/en/developer/csharp-driver/3.20/features/speculative-retries/#query-idempotence
         var scyllaCluster = Cluster.Builder()
             .AddContactPoints(scyllaConnectionString.Split(','))
             .WithSpeculativeExecutionPolicy(new ConstantSpeculativeExecutionPolicy(500, 2))
+            .WithQueryOptions(new QueryOptions()
+                .SetDefaultIdempotence(true))
             .Build();
         sc.AddSingleton<ICluster>(scyllaCluster);
 


### PR DESCRIPTION
By default, query idempotence for custom statements is set to false, so speculative execution is never used. Here, we never use non-idempotent CQL statements (as defined by the docs), so we can default to true for this setting.

https://docs.datastax.com/en/developer/csharp-driver/3.20/features/speculative-retries/#query-idempotence