### PR TITLE
Raise sales DB concurrency to 100 requests

### DIFF
--- a/src/Universalis.DbAccess/MarketBoard/SaleStore.cs
+++ b/src/Universalis.DbAccess/MarketBoard/SaleStore.cs
@@ -29,7 +29,7 @@ public class SaleStore : ISaleStore, IDisposable
         _cache = cache;
         _logger = logger;
 
-        _lock = new SemaphoreSlim(50, 50);
+        _lock = new SemaphoreSlim(100, 100);
 
         // Doing database initialization in a constructor is a Bad Idea and
         // can lead to timeouts killing the application, so this just gets


### PR DESCRIPTION
Raises the concurrency of `RetrieveBySaleTime` to 100 concurrent requests, to hopefully mitigate a [spike in timeouts](https://monitor.universalis.app/d/3PpqjXv4k/universalis?orgId=1&from=1709078082905&to=1709493263233) (auth is `guest`/`guest`). It's unclear if this will actually help or if it'll just cause the DB to be overloaded, unfortunately - but it's worth a shot.