### PR TITLE
Downgrade Npgsql back to 8.0.2 due to a new method not found exception

### DIFF
--- a/src/Universalis.DbAccess/Universalis.DbAccess.csproj
+++ b/src/Universalis.DbAccess/Universalis.DbAccess.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="Npgsql.Json.NET" Version="8.0.3" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="8.0.2" />
+    <PackageReference Include="Npgsql.Json.NET" Version="8.0.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.7" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />


### PR DESCRIPTION
Method not found: 'System.Type[] Npgsql.Internal.PgSerializerOptions.get_WellKnownTextTypes()'.