### PR TITLE
Skip sales DB call when entries==0 for currently shown API call (#1318)

### DIFF
--- a/src/Universalis.DbAccess.Tests/MarketBoard/HistoryDbAccessTests.cs
+++ b/src/Universalis.DbAccess.Tests/MarketBoard/HistoryDbAccessTests.cs
@@ -163,4 +163,32 @@ public class HistoryDbAccessTests
 
         Assert.Equal(sortedExpected, sortedActual[0]);
     }
+
+    [Fact]
+    public async Task Retrieve_ReturnsNull_ForZeroEntriesQuery()
+    {
+        var db = new HistoryDbAccess(new MockMarketItemStore(), new MockSaleStore());
+
+        var document = SeedDataGenerator.MakeHistory(74, 5333);
+        await db.Create(document);
+
+        var output = (await db.Retrieve(new HistoryQuery
+            { WorldId = document.WorldId, ItemId = document.ItemId, Count = 0 }));
+
+        Assert.Null(output);
+    }
+
+    [Fact]
+    public async Task RetrieveMany_ReturnsEmpty_ForZeroEntriesQuery()
+    {
+        var db = new HistoryDbAccess(new MockMarketItemStore(), new MockSaleStore());
+
+        var document = SeedDataGenerator.MakeHistory(74, 5333);
+        await db.Create(document);
+
+        var output = (await db.RetrieveMany(new HistoryManyQuery
+            { WorldIds = new[] { document.WorldId }, ItemIds = new[] { document.ItemId }, Count = 0 }))?.ToList();
+
+        Assert.Empty(output);
+    }
 }

--- a/src/Universalis.DbAccess/MarketBoard/HistoryDbAccess.cs
+++ b/src/Universalis.DbAccess/MarketBoard/HistoryDbAccess.cs
@@ -36,6 +36,11 @@ public class HistoryDbAccess : IHistoryDbAccess
 
     public async Task<History> Retrieve(HistoryQuery query, CancellationToken cancellationToken = default)
     {
+        if (query.Count == 0)
+        {
+            return null;
+        }
+
         using var activity = Util.ActivitySource.StartActivity("HistoryDbAccess.Retrieve");
 
         var marketItem =
@@ -60,6 +65,11 @@ public class HistoryDbAccess : IHistoryDbAccess
     public async Task<IEnumerable<History>> RetrieveMany(HistoryManyQuery query,
         CancellationToken cancellationToken = default)
     {
+        if (query.Count == 0)
+        {
+            return Enumerable.Empty<History>();
+        }
+
         using var activity = Util.ActivitySource.StartActivity("HistoryDbAccess.RetrieveMany");
 
         // Build tuples of world/item pairs - the awkward syntax here avoids allocations besides the ToArray calls


### PR DESCRIPTION
This PR is part of the optimization effort to reduce the load on the Universalis API.

This is a simple change to completely skip accessing the `sales` DB when `entries` query parameter is set to 0, which would otherwise result in a query that returns 0 rows (see [LIMIT usage](https://github.com/Universalis-FFXIV/Universalis/blob/908189276693f608e2837c2740ec67c4a699507a/src/Universalis.DbAccess/MarketBoard/SaleStore.cs#L178)).

In addition, this PR updates the tests in `Universalis.DbAccess.Tests.MarketBoard.CurrentlyShownStoreTests` to reflect recent changes, including the removal of the seller/creator CIDs (#1345).