### PR TITLE
Reject uploads with invalid LastReviewTime

### DIFF
--- a/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
+++ b/src/Universalis.Application.Tests/Uploads/Behaviors/MarketBoardUploadBehaviorTests.cs
@@ -152,6 +152,27 @@ public class MarketBoardUploadBehaviorTests
         Assert.False(test.Behavior.ShouldExecute(upload));
     }
 
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    [InlineData(null)]
+    public void Behavior_DoesNotRun_WithInvalidReviewTimeListings(long? lastReviewTimeUnixSeconds)
+    {
+        var test = TestResources.Create();
+
+        var (listings, _) = SchemaSeedDataGenerator.GetUploadListingsAndSales(74, 5333);
+        listings[0].LastReviewTimeUnixSeconds = lastReviewTimeUnixSeconds;
+
+        var upload = new UploadParameters
+        {
+            WorldId = 74,
+            ItemId = 5333,
+            UploaderId = "5627384655756342554",
+            Listings = listings,
+        };
+        Assert.False(test.Behavior.ShouldExecute(upload));
+    }
+
     [Fact]
     public void Behavior_DoesNotRun_WithInvalidStackSizeListings()
     {

--- a/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
+++ b/src/Universalis.Application/Uploads/Behaviors/MarketBoardUploadBehavior.cs
@@ -97,10 +97,7 @@ public class MarketBoardUploadBehavior : IUploadBehavior
 
         if (parameters.Listings != null)
         {
-            if (parameters.Listings.Any(l =>
-                    Util.HasHtmlTags(l.ListingId) || Util.HasHtmlTags(l.RetainerName) ||
-                    Util.HasHtmlTags(l.RetainerId) || Util.HasHtmlTags(l.CreatorName) || Util.HasHtmlTags(l.SellerId) ||
-                    Util.HasHtmlTags(l.CreatorId)))
+            if (parameters.Listings.Any(IsInvalid))
             {
                 return new BadRequestResult();
             }
@@ -109,6 +106,20 @@ public class MarketBoardUploadBehavior : IUploadBehavior
         }
 
         return null;
+    }
+
+    private static bool IsInvalid(Universalis.Application.Uploads.Schema.Listing l)
+    {
+        // Listings can be up for at most 7 days - checking against 8 to give some buffer
+        var lastReviewTime = DateTimeOffset.FromUnixTimeSeconds(l.LastReviewTimeUnixSeconds ?? 0).UtcDateTime;
+        if ((DateTime.UtcNow - lastReviewTime).TotalDays >= 8)
+        {
+            return false;
+        }
+
+        return Util.HasHtmlTags(l.ListingId) || Util.HasHtmlTags(l.RetainerName) ||
+               Util.HasHtmlTags(l.RetainerId) || Util.HasHtmlTags(l.CreatorName) || Util.HasHtmlTags(l.SellerId) ||
+               Util.HasHtmlTags(l.CreatorId);
     }
 
     private async Task HandleListings(IList<Schema.Listing> uploadedListings, int itemId, int worldId,

--- a/src/Universalis.Application/Uploads/Schema/Listing.cs
+++ b/src/Universalis.Application/Uploads/Schema/Listing.cs
@@ -70,7 +70,7 @@ public class Listing
     public int? DyeId { get; init; }
 
     [JsonPropertyName("lastReviewTime")]
-    public long? LastReviewTimeUnixSeconds { get; init; }
+    public long? LastReviewTimeUnixSeconds { get; set; }
         
     [JsonPropertyName("materia")]
     public List<Materia> Materia { get; init; }


### PR DESCRIPTION
Fixes an issue where some listings have a `lastReviewTime` of 0 in the API.