### PR TITLE
Implement HasData property in current data queries

### DIFF
--- a/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V1/CurrentlyShownControllerTests.cs
@@ -326,6 +326,7 @@ public class CurrentlyShownControllerTests
         Assert.NotNull(history.RecentHistory);
         Assert.Empty(history.RecentHistory);
         Assert.Equal(0, history.LastUploadTimeUnixMilliseconds);
+        Assert.False(history.HasData);
         Assert.NotNull(history.StackSizeHistogram);
         Assert.Empty(history.StackSizeHistogram);
         Assert.NotNull(history.StackSizeHistogramNq);
@@ -380,6 +381,7 @@ public class CurrentlyShownControllerTests
         Assert.NotNull(history.RecentHistory);
         Assert.Empty(history.RecentHistory);
         Assert.Equal(0, history.LastUploadTimeUnixMilliseconds);
+        Assert.False(history.HasData);
         Assert.NotNull(history.StackSizeHistogram);
         Assert.Empty(history.StackSizeHistogram);
         Assert.NotNull(history.StackSizeHistogramNq);
@@ -525,6 +527,7 @@ public class CurrentlyShownControllerTests
         Assert.Equal(document.WorldId, currentlyShown.WorldId);
         Assert.Equal(gameData.AvailableWorlds()[document.WorldId], currentlyShown.WorldName);
         Assert.Equal(document.LastUploadTimeUnixMilliseconds / 1000, currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.True(currentlyShown.HasData);
         Assert.Null(currentlyShown.DcName);
 
         Assert.NotNull(currentlyShown.Listings);
@@ -570,6 +573,7 @@ public class CurrentlyShownControllerTests
     {
         Assert.Equal(anyWorldDocument.ItemId, currentlyShown.ItemId);
         Assert.Equal(lastUploadTime / 1000, currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.True(currentlyShown.HasData);
         Assert.Equal(char.ToUpperInvariant(worldOrDc[0]) + worldOrDc[1..].ToLowerInvariant(), currentlyShown.DcName);
         Assert.Null(currentlyShown.WorldId);
         Assert.Null(currentlyShown.WorldName);

--- a/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
+++ b/src/Universalis.Application.Tests/Controllers/V2/CurrentlyShownControllerTests.cs
@@ -213,6 +213,7 @@ public class CurrentlyShownControllerTests
         Assert.NotNull(history.RecentHistory);
         Assert.Empty(history.RecentHistory);
         Assert.Equal(0, history.LastUploadTimeUnixMilliseconds);
+        Assert.False(history.HasData);
         Assert.NotNull(history.StackSizeHistogram);
         Assert.Empty(history.StackSizeHistogram);
         Assert.NotNull(history.StackSizeHistogramNq);
@@ -265,6 +266,7 @@ public class CurrentlyShownControllerTests
         Assert.NotNull(history.RecentHistory);
         Assert.Empty(history.RecentHistory);
         Assert.Equal(0, history.LastUploadTimeUnixMilliseconds);
+        Assert.False(history.HasData);
         Assert.NotNull(history.StackSizeHistogram);
         Assert.Empty(history.StackSizeHistogram);
         Assert.NotNull(history.StackSizeHistogramNq);
@@ -417,6 +419,7 @@ public class CurrentlyShownControllerTests
         Assert.Equal(gameData.AvailableWorlds()[document.WorldId], currentlyShown.WorldName);
         Assert.Equal(document.LastUploadTimeUnixMilliseconds / 1000,
             currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.True(currentlyShown.HasData);
         Assert.Null(currentlyShown.DcName);
 
         Assert.NotNull(currentlyShown.Listings);
@@ -488,6 +491,7 @@ public class CurrentlyShownControllerTests
     {
         Assert.Equal(anyWorldDocument.ItemId, currentlyShown.ItemId);
         Assert.Equal(lastUploadTime / 1000, currentlyShown.LastUploadTimeUnixMilliseconds / 1000);
+        Assert.True(currentlyShown.HasData);
         Assert.Equal(char.ToUpperInvariant(worldOrDc[0]) + worldOrDc[1..].ToLowerInvariant(), currentlyShown.DcName);
         Assert.Null(currentlyShown.WorldId);
         Assert.Null(currentlyShown.WorldName);

--- a/src/Universalis.Application/Views/V1/CurrentlyShownView.cs
+++ b/src/Universalis.Application/Views/V1/CurrentlyShownView.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Universalis.Application.Common;
 
@@ -210,4 +209,10 @@ public class CurrentlyShownView : PartiallySerializable
     /// </summary>
     [JsonPropertyName("unitsSold")]
     public int UnitsSold { get; init; }
+
+    /// <summary>
+    /// Whether this item has ever been updated. Useful for newly-released items.
+    /// </summary>
+    [JsonPropertyName("hasData")]
+    public bool HasData => LastUploadTimeUnixMilliseconds != 0;
 }


### PR DESCRIPTION
Enables easily distinguishing cases where an item has never been updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `HasData` property in the `CurrentlyShownView` class to indicate the presence of data.

- **Bug Fixes**
	- Enhanced test assertions to ensure the `HasData` property is validated in various test scenarios for both single and multi-item retrievals.

- **Style**
	- Minor adjustments made to code formatting for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->