### PR TITLE
Compare listings by their ID, quantity and PPU

### DIFF
--- a/src/Universalis.Entities/MarketBoard/Listing.cs
+++ b/src/Universalis.Entities/MarketBoard/Listing.cs
@@ -47,7 +47,21 @@ public partial class Listing : IEquatable<Listing>
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return ListingId == other.ListingId;
+        return ListingId == other.ListingId &&
+               Hq == other.Hq &&
+               OnMannequin == other.OnMannequin &&
+               PricePerUnit == other.PricePerUnit &&
+               Quantity == other.Quantity &&
+               DyeId == other.DyeId &&
+               CreatorId == other.CreatorId &&
+               CreatorName == other.CreatorName &&
+               LastReviewTime.Equals(other.LastReviewTime) &&
+               RetainerId == other.RetainerId &&
+               RetainerName == other.RetainerName &&
+               RetainerCityId == other.RetainerCityId &&
+               SellerId == other.SellerId &&
+               ItemId == other.ItemId &&
+               WorldId == other.WorldId;
     }
 
     public override bool Equals(object obj)

--- a/src/Universalis.Entities/MarketBoard/Listing.cs
+++ b/src/Universalis.Entities/MarketBoard/Listing.cs
@@ -48,20 +48,8 @@ public partial class Listing : IEquatable<Listing>
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
         return ListingId == other.ListingId &&
-               Hq == other.Hq &&
-               OnMannequin == other.OnMannequin &&
                PricePerUnit == other.PricePerUnit &&
-               Quantity == other.Quantity &&
-               DyeId == other.DyeId &&
-               CreatorId == other.CreatorId &&
-               CreatorName == other.CreatorName &&
-               LastReviewTime.Equals(other.LastReviewTime) &&
-               RetainerId == other.RetainerId &&
-               RetainerName == other.RetainerName &&
-               RetainerCityId == other.RetainerCityId &&
-               SellerId == other.SellerId &&
-               ItemId == other.ItemId &&
-               WorldId == other.WorldId;
+               Quantity == other.Quantity;
     }
 
     public override bool Equals(object obj)
@@ -75,20 +63,8 @@ public partial class Listing : IEquatable<Listing>
     {
         var hashCode = new HashCode();
         hashCode.Add(ListingId);
-        hashCode.Add(Hq);
-        hashCode.Add(OnMannequin);
         hashCode.Add(PricePerUnit);
         hashCode.Add(Quantity);
-        hashCode.Add(DyeId);
-        hashCode.Add(CreatorId);
-        hashCode.Add(CreatorName);
-        hashCode.Add(LastReviewTime);
-        hashCode.Add(RetainerId);
-        hashCode.Add(RetainerName);
-        hashCode.Add(RetainerCityId);
-        hashCode.Add(SellerId);
-        hashCode.Add(ItemId);
-        hashCode.Add(WorldId);
         return hashCode.ToHashCode();
     }
 


### PR DESCRIPTION
When only price (or quantity?) of a listing is changed, the listing will be republished with the same listing ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Refined the criteria for comparing market board listings, ensuring that items are identified more consistently. This update enhances the reliability of how listings are processed, delivering a more robust and accurate experience when browsing available market items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->