### PR TITLE
Remove multithreading from SocketProcessor for now

### DIFF
--- a/src/Universalis.Application.Tests/Realtime/SocketProcessorTests.cs
+++ b/src/Universalis.Application.Tests/Realtime/SocketProcessorTests.cs
@@ -22,7 +22,7 @@ public class SocketProcessorTests
         // Arrange
         var loggerMock = new Mock<ILogger<SocketProcessor>>();
 
-        using var socketProcessor = new SocketProcessor(loggerMock.Object);
+        var socketProcessor = new SocketProcessor(loggerMock.Object);
 
         var clientMocks = FactoryList.OfLength(2, _ => new Mock<ISocketClient>());
         var messages = FactoryList.OfLength(2500, _ => Mock.Of<SocketMessage>());
@@ -47,7 +47,7 @@ public class SocketProcessorTests
     {
         // Arrange
         var loggerMock = new Mock<ILogger<SocketProcessor>>();
-        using var socketProcessor = new SocketProcessor(loggerMock.Object);
+        var socketProcessor = new SocketProcessor(loggerMock.Object);
 
         var client1Mock = new Mock<ISocketClient>();
         var client2Mock = new Mock<ISocketClient>();
@@ -81,7 +81,7 @@ public class SocketProcessorTests
         var taskCompletionSource = new TaskCompletionSource<object>();
         var cancellationToken = new CancellationToken();
 
-        using var socketProcessor = new SocketProcessor(loggerMock.Object);
+        var socketProcessor = new SocketProcessor(loggerMock.Object);
 
         // Act
         socketProcessor.AddSocket(webSocketMock.Object, taskCompletionSource, cancellationToken);

--- a/src/Universalis.Application/Realtime/SocketProcessor.cs
+++ b/src/Universalis.Application/Realtime/SocketProcessor.cs
@@ -12,7 +12,7 @@ using Universalis.Application.Realtime.Messages;
 
 namespace Universalis.Application.Realtime;
 
-public class SocketProcessor : ISocketProcessor, IDisposable
+public class SocketProcessor(ILogger<SocketProcessor> logger) : ISocketProcessor
 {
     private const int NumWorkers = 8;
 
@@ -31,56 +31,19 @@ public class SocketProcessor : ISocketProcessor, IDisposable
     private static readonly Counter MessagesSent = Metrics.CreateCounter(
         "universalis_ws_sent",
         "WebSocket Messages Sent");
-    private static readonly Counter WorkerExceptions = Metrics.CreateCounter(
-        "universalis_ws_worker_exceptions",
-        "WebSocket Worker Exceptions");
 
     private readonly ConcurrentDictionary<Guid, ISocketClient> _connections = new();
-    private readonly BlockingCollection<Action> _taskQueue = new();
-    private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private readonly List<Thread> _workers = [];
-    private readonly ILogger<SocketProcessor> _logger;
-
-    public SocketProcessor(ILogger<SocketProcessor> logger)
-    {
-        _logger = logger;
-
-        for (var i = 0; i < NumWorkers; i++)
-        {
-            CreateWorkerThread();
-        }
-    }
 
     public void Publish(SocketMessage message)
     {
         var stopwatch = new Stopwatch();
         stopwatch.Start();
 
-        // Prebuild the list of tasks to avoid a race condition between creating the
-        // countdown event with a specific count and dispatching the tasks themselves.
-        // Instead of using _connections.Count and then separately iterating over it,
-        // We iterate the connections and then get the count of the resulting list.
-        // We could use a lock here, but the fewer locks, the better.
-        var newTasks = _connections
-            .Select(kvp => kvp.Value)
-            .Select(connection => CreatePushMessageTask(connection, message))
-            .ToList();
-
-        // Enqueue tasks for all connected clients
-        using var countdownEvent = new CountdownEvent(newTasks.Count);
-        foreach (var task in newTasks)
+        foreach (var (_, connection) in _connections)
         {
-            _taskQueue.Add(() =>
-            {
-                task();
-
-                // ReSharper disable once AccessToDisposedClosure
-                countdownEvent.Signal();
-            });
+            connection.Push(message);
+            MessagesSent.Inc();
         }
-
-        // Wait until all clients have processed the message
-        countdownEvent.Wait();
 
         stopwatch.Stop();
         MessageQueueTime.Observe(stopwatch.ElapsedMilliseconds);
@@ -90,7 +53,7 @@ public class SocketProcessor : ISocketProcessor, IDisposable
     {
         var id = Guid.NewGuid();
 
-        var conn = new SocketClient(ws, cs, new LoggerShield<SocketProcessor>(_logger, id));
+        var conn = new SocketClient(ws, cs, new LoggerShield<SocketProcessor>(logger, id));
         conn.OnClose += () =>
         {
             _connections.TryRemove(id, out _);
@@ -101,67 +64,5 @@ public class SocketProcessor : ISocketProcessor, IDisposable
 
         _connections[id] = conn;
         WebSocketConnections.Inc();
-    }
-
-    private void ProcessQueue()
-    {
-        var logger = new LoggerShield<SocketProcessor>(_logger, "Universalis SocketProcessor Worker");
-        try
-        {
-            foreach (var task in _taskQueue.GetConsumingEnumerable(_cancellationTokenSource.Token))
-            {
-                try
-                {
-                    task();
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Error while processing task");
-                    WorkerExceptions.Inc();
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            logger.LogInformation("Queue worker cancelled");
-        }
-    }
-
-    private static Action CreatePushMessageTask(ISocketClient connection, SocketMessage message)
-    {
-        return () =>
-        {
-            connection.Push(message);
-            MessagesSent.Inc();
-        };
-    }
-
-    private void CreateWorkerThread()
-    {
-        var thread = new Thread(ProcessQueue)
-        {
-            IsBackground = true,
-            Name = "Universalis SocketProcessor Worker",
-        };
-        _workers.Add(thread);
-        thread.Start();
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-
-        // Mark the queue as completed
-        _cancellationTokenSource.Cancel();
-        _taskQueue.CompleteAdding();
-
-        // Wait for all worker threads to complete
-        foreach (var worker in _workers)
-        {
-            worker.Join();
-        }
-
-        _taskQueue.Dispose();
-        _cancellationTokenSource.Dispose();
     }
 }


### PR DESCRIPTION
No clue why it just stopped working after several hours - there are no indicative changes in logs or metrics that suggest a reason for this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and reliability of real-time socket message processing by simplifying how messages are sent to connected clients.
  - Reduced background processing overhead, leading to more predictable and synchronous message delivery.
- **Tests**
  - Updated tests to align with the new synchronous processing model for socket messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->