### PR TITLE
Compare timestamps correctly and without overflows

### DIFF
--- a/src/Universalis.DbAccess.Tests/Uploads/MostRecentlyUpdatedDbAccessTests.cs
+++ b/src/Universalis.DbAccess.Tests/Uploads/MostRecentlyUpdatedDbAccessTests.cs
@@ -13,17 +13,21 @@ public class MostRecentlyUpdatedDbAccessTests
 {
     private class MockWorldItemUploadStore : IWorldItemUploadStore
     {
-        private readonly Dictionary<int, double> _scores = new();
+        private readonly Dictionary<(int worldId, int itemId), double> _scores = new();
 
         public Task SetItem(int worldId, int itemId, double val)
         {
-            _scores[itemId] = val;
+            _scores[(worldId, itemId)] = val;
             return Task.CompletedTask;
         }
 
         public Task<IList<KeyValuePair<int, double>>> GetMostRecent(int worldId, int stop = -1)
         {
-            var en = _scores.OrderByDescending(s => s.Value).ToList();
+            var en = _scores
+                .Where(kvp => kvp.Key.worldId == worldId)
+                .Select(kvp => new KeyValuePair<int, double>(kvp.Key.itemId, kvp.Value))
+                .OrderByDescending(s => s.Value)
+                .ToList();
             if (stop > -1)
             {
                 en = en.Take(stop + 1).ToList();
@@ -34,7 +38,11 @@ public class MostRecentlyUpdatedDbAccessTests
 
         public Task<IList<KeyValuePair<int, double>>> GetLeastRecent(int worldId, int stop = -1)
         {
-            var en = _scores.OrderBy(s => s.Value).ToList();
+            var en = _scores
+                .Where(kvp => kvp.Key.worldId == worldId)
+                .Select(kvp => new KeyValuePair<int, double>(kvp.Key.itemId, kvp.Value))
+                .OrderBy(s => s.Value)
+                .ToList();
             if (stop > -1)
             {
                 en = en.Take(stop + 1).ToList();
@@ -45,7 +53,8 @@ public class MostRecentlyUpdatedDbAccessTests
 
         public Task<double?> GetUploadTime(int worldId, int itemId)
         {
-            return Task.FromResult<double?>(_scores.TryGetValue(itemId, out var timestamp) ? timestamp : null);
+            return Task.FromResult<double?>(
+                _scores.TryGetValue((worldId, itemId), out var timestamp) ? timestamp : null);
         }
     }
 
@@ -185,5 +194,320 @@ public class MostRecentlyUpdatedDbAccessTests
         });
         Assert.NotNull(output);
         Assert.Equal(10, output.Count);
+    }
+
+    [Fact]
+    public async Task GetAllMostRecent_EmptyWorlds_ReturnsEmpty()
+    {
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(new MockWorldItemUploadStore());
+        var output = await db.GetAllMostRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 10,
+        });
+
+        Assert.NotNull(output);
+        Assert.Empty(output);
+    }
+
+    [Fact]
+    public async Task GetAllMostRecent_MultipleWorlds_ReturnsMostRecent()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        var baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 1000 });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 3, LastUploadTimeUnixMilliseconds = baseTime + 2000 });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 4, LastUploadTimeUnixMilliseconds = baseTime + 3000 });
+
+        var output = await db.GetAllMostRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 3,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(3, output.Count);
+        Assert.Equal(4, output[0].ItemId);
+        Assert.Equal(75, output[0].WorldId);
+        Assert.Equal(3, output[1].ItemId);
+        Assert.Equal(75, output[1].WorldId);
+        Assert.Equal(2, output[2].ItemId);
+        Assert.Equal(74, output[2].WorldId);
+    }
+
+    [Fact]
+    public async Task GetAllMostRecent_CountExceedsItems_ReturnsAll()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        var baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 1000 });
+
+        var output = await db.GetAllMostRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 10,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(2, output.Count);
+    }
+
+    [Fact]
+    public async Task GetLeastRecent_EmptyWorld_ReturnsEmpty()
+    {
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(new MockWorldItemUploadStore());
+        var output = await db.GetLeastRecent(new MostRecentlyUpdatedQuery
+        {
+            WorldId = 74,
+            Count = 10,
+        });
+
+        Assert.NotNull(output);
+        Assert.Empty(output);
+    }
+
+    [Fact]
+    public async Task GetLeastRecent_MultipleItems_ReturnsLeastRecent()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        var baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 1000 });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 3, LastUploadTimeUnixMilliseconds = baseTime + 2000 });
+
+        var output = await db.GetLeastRecent(new MostRecentlyUpdatedQuery
+        {
+            WorldId = 74,
+            Count = 2,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(2, output.Count);
+        Assert.Equal(1, output[0].ItemId);
+        Assert.Equal(2, output[1].ItemId);
+    }
+
+    [Fact]
+    public async Task GetLeastRecent_TakesCount()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        for (var i = 0; i < 20; i++)
+        {
+            await db.Push(74, new WorldItemUpload
+            {
+                WorldId = 74,
+                ItemId = i,
+                LastUploadTimeUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + i,
+            });
+        }
+
+        var output = await db.GetLeastRecent(new MostRecentlyUpdatedQuery
+        {
+            WorldId = 74,
+            Count = 5,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(5, output.Count);
+        Assert.Equal(0, output[0].ItemId);
+    }
+
+    [Fact]
+    public async Task GetAllLeastRecent_EmptyWorlds_ReturnsEmpty()
+    {
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(new MockWorldItemUploadStore());
+        var output = await db.GetAllLeastRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 10,
+        });
+
+        Assert.NotNull(output);
+        Assert.Empty(output);
+    }
+
+    [Fact]
+    public async Task GetAllLeastRecent_MultipleWorlds_ReturnsLeastRecent()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        var baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 1000 });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 3, LastUploadTimeUnixMilliseconds = baseTime + 2000 });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 4, LastUploadTimeUnixMilliseconds = baseTime + 3000 });
+
+        var output = await db.GetAllLeastRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 3,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(3, output.Count);
+        Assert.Equal(1, output[0].ItemId);
+        Assert.Equal(74, output[0].WorldId);
+        Assert.Equal(2, output[1].ItemId);
+        Assert.Equal(74, output[1].WorldId);
+        Assert.Equal(3, output[2].ItemId);
+        Assert.Equal(75, output[2].WorldId);
+    }
+
+    [Fact]
+    public async Task GetAllLeastRecent_CountExceedsItems_ReturnsAll()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        var baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 1000 });
+
+        var output = await db.GetAllLeastRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 10,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(2, output.Count);
+    }
+
+    [Fact]
+    public async Task GetAllLeastRecent_WithRealisticTimestamps_ReturnsCorrectOrder()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        // Use realistic Unix timestamps (milliseconds since epoch)
+        // These large values would cause integer overflow with (int)(b - a)
+        var baseTime = 1727827200000L; // Oct 2, 2024
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 5000000000L });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 3, LastUploadTimeUnixMilliseconds = baseTime + 1000000000L });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 4, LastUploadTimeUnixMilliseconds = baseTime + 3000000000L });
+
+        var output = await db.GetAllLeastRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 4,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(4, output.Count);
+        // Should be ordered by timestamp ascending (least recent first)
+        Assert.Equal(1, output[0].ItemId); // baseTime
+        Assert.Equal(3, output[1].ItemId); // baseTime + 1B
+        Assert.Equal(4, output[2].ItemId); // baseTime + 3B
+        Assert.Equal(2, output[3].ItemId); // baseTime + 5B
+    }
+
+    [Fact]
+    public async Task GetAllMostRecent_WithRealisticTimestamps_ReturnsCorrectOrder()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        // Use realistic Unix timestamps (milliseconds since epoch)
+        var baseTime = 1727827200000L; // Oct 2, 2024
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = baseTime });
+        await db.Push(74,
+            new WorldItemUpload { WorldId = 74, ItemId = 2, LastUploadTimeUnixMilliseconds = baseTime + 5000000000L });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 3, LastUploadTimeUnixMilliseconds = baseTime + 1000000000L });
+        await db.Push(75,
+            new WorldItemUpload { WorldId = 75, ItemId = 4, LastUploadTimeUnixMilliseconds = baseTime + 3000000000L });
+
+        var output = await db.GetAllMostRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 4,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(4, output.Count);
+        // Should be ordered by timestamp descending (most recent first)
+        Assert.Equal(2, output[0].ItemId); // baseTime + 5B
+        Assert.Equal(4, output[1].ItemId); // baseTime + 3B
+        Assert.Equal(3, output[2].ItemId); // baseTime + 1B
+        Assert.Equal(1, output[3].ItemId); // baseTime
+    }
+
+    [Fact]
+    public async Task GetAllMostRecent_WithTimestampsCausingIntOverflow_ReturnsCorrectOrder()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        // Create timestamps from different times that will cause int overflow when subtracted
+        // Timestamps from Jan 2020 vs Oct 2024 - difference exceeds int.MaxValue
+        var oldTime = 1577836800000.0; // Jan 1, 2020
+        var newTime = 1727827200000.0; // Oct 2, 2024
+        // Difference: ~150 billion, which exceeds int.MaxValue (~2.1 billion)
+
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = oldTime });
+        await db.Push(75, new WorldItemUpload { WorldId = 75, ItemId = 2, LastUploadTimeUnixMilliseconds = newTime });
+
+        var output = await db.GetAllMostRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 2,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(2, output.Count);
+        // Item 2 should be first (most recent)
+        Assert.Equal(2, output[0].ItemId);
+        Assert.Equal(1, output[1].ItemId);
+    }
+
+    [Fact]
+    public async Task GetAllLeastRecent_WithTimestampsCausingIntOverflow_ReturnsCorrectOrder()
+    {
+        var store = new MockWorldItemUploadStore();
+        IMostRecentlyUpdatedDbAccess db = new MostRecentlyUpdatedDbAccess(store);
+
+        // Create timestamps from different times that will cause int overflow when subtracted
+        var oldTime = 1577836800000.0; // Jan 1, 2020
+        var newTime = 1727827200000.0; // Oct 2, 2024
+
+        await db.Push(74, new WorldItemUpload { WorldId = 74, ItemId = 1, LastUploadTimeUnixMilliseconds = oldTime });
+        await db.Push(75, new WorldItemUpload { WorldId = 75, ItemId = 2, LastUploadTimeUnixMilliseconds = newTime });
+
+        var output = await db.GetAllLeastRecent(new MostRecentlyUpdatedManyQuery
+        {
+            WorldIds = new[] { 74, 75 },
+            Count = 2,
+        });
+
+        Assert.NotNull(output);
+        Assert.Equal(2, output.Count);
+        // Item 1 should be first (least recent)
+        Assert.Equal(1, output[0].ItemId);
+        Assert.Equal(2, output[1].ItemId);
     }
 }

--- a/src/Universalis.DbAccess/Uploads/MostRecentlyUpdatedDbAccess.cs
+++ b/src/Universalis.DbAccess/Uploads/MostRecentlyUpdatedDbAccess.cs
@@ -23,7 +23,8 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
             document.LastUploadTimeUnixMilliseconds);
     }
 
-    public async Task<IList<WorldItemUpload>> GetMostRecent(MostRecentlyUpdatedQuery query, CancellationToken cancellationToken = default)
+    public async Task<IList<WorldItemUpload>> GetMostRecent(MostRecentlyUpdatedQuery query,
+        CancellationToken cancellationToken = default)
     {
         var data = await _store.GetMostRecent(query.WorldId, query.Count - 1);
         return data.Select(kvp => new WorldItemUpload
@@ -34,7 +35,8 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
         }).ToList();
     }
 
-    public async Task<IList<WorldItemUpload>> GetAllMostRecent(MostRecentlyUpdatedManyQuery query, CancellationToken cancellationToken = default)
+    public async Task<IList<WorldItemUpload>> GetAllMostRecent(MostRecentlyUpdatedManyQuery query,
+        CancellationToken cancellationToken = default)
     {
         var data = await query.WorldIds.ToAsyncEnumerable()
             .SelectManyAwait(async world =>
@@ -49,8 +51,8 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
                     });
             })
             .ToListAsync(cancellationToken);
-        
-        var heap = new SimplePriorityQueue<WorldItemUpload, double>(Comparer<double>.Create((a, b) => (int)(b - a)));
+
+        var heap = new SimplePriorityQueue<WorldItemUpload, double>(Comparer<double>.Create((a, b) => b.CompareTo(a)));
         foreach (var d in data)
         {
             // Build a heap
@@ -69,8 +71,9 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
 
         return outData;
     }
-    
-    public async Task<IList<WorldItemUpload>> GetLeastRecent(MostRecentlyUpdatedQuery query, CancellationToken cancellationToken = default)
+
+    public async Task<IList<WorldItemUpload>> GetLeastRecent(MostRecentlyUpdatedQuery query,
+        CancellationToken cancellationToken = default)
     {
         var data = await _store.GetLeastRecent(query.WorldId, query.Count - 1);
         return data.Select(kvp => new WorldItemUpload
@@ -81,7 +84,8 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
         }).ToList();
     }
 
-    public async Task<IList<WorldItemUpload>> GetAllLeastRecent(MostRecentlyUpdatedManyQuery query, CancellationToken cancellationToken = default)
+    public async Task<IList<WorldItemUpload>> GetAllLeastRecent(MostRecentlyUpdatedManyQuery query,
+        CancellationToken cancellationToken = default)
     {
         var data = await query.WorldIds.ToAsyncEnumerable()
             .SelectManyAwait(async world =>
@@ -96,12 +100,12 @@ public class MostRecentlyUpdatedDbAccess : IMostRecentlyUpdatedDbAccess
                     });
             })
             .ToListAsync(cancellationToken);
-        
-        var heap = new SimplePriorityQueue<WorldItemUpload, double>(Comparer<double>.Create((a, b) => (int)(b - a)));
+
+        var heap = new SimplePriorityQueue<WorldItemUpload, double>(Comparer<double>.Create((a, b) => a.CompareTo(b)));
         foreach (var d in data)
         {
-            // Build a heap but make the timestamp negative to reverse it
-            heap.Enqueue(d, -d.LastUploadTimeUnixMilliseconds);
+            // Build a min heap
+            heap.Enqueue(d, d.LastUploadTimeUnixMilliseconds);
         }
 
         var outData = new List<WorldItemUpload>();


### PR DESCRIPTION
Should fix the least-recently-updated endpoint showing incorrect results on data centers vs. single worlds.